### PR TITLE
feat: implement JWT authentication, role guards and ownership control (ID8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,5 @@ jobs:
         env:
           DATABASE_URL: postgresql://dummy:placeholder@localhost:5432/ci
       - run: npm run test -w apps/backend
+        env:
+          JWT_SECRET: ci-secret-for-testing-only

--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -30,7 +30,12 @@ describe('AuthController', () => {
         password: 'Str0ng!',
         role: Role.CLIENT,
       };
-      const expected = { id: 'uuid-1', name: dto.name, email: dto.email, role: dto.role };
+      const expected = {
+        id: 'uuid-1',
+        name: dto.name,
+        email: dto.email,
+        role: dto.role,
+      };
       mockAuthService.register.mockResolvedValue(expected);
 
       const result = await controller.register(dto);

--- a/apps/backend/src/auth/auth.controller.spec.ts
+++ b/apps/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { Role } from '../users/dto/create-user.dto';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  const mockAuthService = {
+    register: jest.fn(),
+    login: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('register', () => {
+    it('should call authService.register with DTO', async () => {
+      const dto = {
+        name: 'John',
+        email: 'john@test.com',
+        password: 'Str0ng!',
+        role: Role.CLIENT,
+      };
+      const expected = { id: 'uuid-1', name: dto.name, email: dto.email, role: dto.role };
+      mockAuthService.register.mockResolvedValue(expected);
+
+      const result = await controller.register(dto);
+
+      expect(mockAuthService.register).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('login', () => {
+    it('should call authService.login with DTO', async () => {
+      const dto = { email: 'john@test.com', password: 'Str0ng!' };
+      const expected = { accessToken: 'jwt-token' };
+      mockAuthService.login.mockResolvedValue(expected);
+
+      const result = await controller.login(dto);
+
+      expect(mockAuthService.login).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  register(@Body() dto: RegisterDto) {
+    return this.authService.register(dto);
+  }
+
+  @Post('login')
+  login(@Body() dto: LoginDto) {
+    return this.authService.login(dto);
+  }
+}

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -1,4 +1,26 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { RolesGuard } from './guards/roles.guard';
+import { UsersModule } from '../users/users.module';
 
-@Module({})
+@Module({
+  imports: [
+    UsersModule,
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.registerAsync({
+      useFactory: () => ({
+        secret: process.env.JWT_SECRET,
+        signOptions: { expiresIn: '7d' },
+      }),
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard, RolesGuard],
+  exports: [JwtAuthGuard, RolesGuard],
+})
 export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcryptjs';
+import { Role } from '../users/dto/create-user.dto';
+
+jest.mock('bcryptjs');
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let bcryptHash: jest.Mock;
+
+  const mockUsersService = {
+    create: jest.fn(),
+    findByEmail: jest.fn(),
+  };
+
+  const mockJwtService = {
+    signAsync: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    bcryptHash = bcrypt.hash as jest.Mock;
+    bcryptHash.mockResolvedValue('hashed-password');
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: JwtService, useValue: mockJwtService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('login', () => {
+    const dto = { email: 'john@test.com', password: 'Str0ng!' };
+
+    it('should return an access token when credentials are valid', async () => {
+      const user = {
+        id: 'uuid-1',
+        email: dto.email,
+        password: 'hashed-password',
+        role: Role.ARTIST,
+      };
+      mockUsersService.findByEmail.mockResolvedValue(user);
+      mockJwtService.signAsync.mockResolvedValue('jwt-token');
+
+      const result = await service.login(dto);
+
+      expect(mockUsersService.findByEmail).toHaveBeenCalledWith(dto.email);
+      expect(bcrypt.compare).toHaveBeenCalledWith(dto.password, user.password);
+      expect(mockJwtService.signAsync).toHaveBeenCalledWith({
+        sub: user.id,
+        email: user.email,
+        role: user.role,
+      });
+      expect(result).toEqual({ accessToken: 'jwt-token' });
+    });
+
+    it('should throw UnauthorizedException when email is not found', async () => {
+      mockUsersService.findByEmail.mockResolvedValue(null);
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when password is invalid', async () => {
+      mockUsersService.findByEmail.mockResolvedValue({
+        id: 'uuid-1',
+        email: dto.email,
+        password: 'hashed-password',
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('register', () => {
+    const dto = {
+      name: 'John',
+      email: 'john@test.com',
+      password: 'Str0ng!',
+      role: Role.CLIENT,
+    };
+
+    it('should create a user with hashed password and return without password', async () => {
+      const hashedPassword = 'hashed-password';
+
+      const createdUser = {
+        id: 'uuid-1',
+        name: dto.name,
+        email: dto.email,
+        password: hashedPassword,
+        role: dto.role,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockUsersService.create.mockResolvedValue(createdUser);
+
+      const result = await service.register(dto);
+
+      expect(bcryptHash).toHaveBeenCalledWith(dto.password, 10);
+      expect(mockUsersService.create).toHaveBeenCalledWith({
+        name: dto.name,
+        email: dto.email,
+        password: hashedPassword,
+        role: dto.role,
+      });
+      expect(result).not.toHaveProperty('password');
+      expect(result).toEqual({
+        id: 'uuid-1',
+        name: dto.name,
+        email: dto.email,
+        role: dto.role,
+        createdAt: createdUser.createdAt,
+        updatedAt: createdUser.updatedAt,
+      });
+    });
+
+    it('should throw ConflictException when email already exists', async () => {
+      mockUsersService.create.mockRejectedValue(
+        new ConflictException('Email already exists'),
+      );
+
+      await expect(service.register(dto)).rejects.toThrow(ConflictException);
+    });
+  });
+});

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,8 +1,4 @@
-import {
-  ConflictException,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcryptjs';
 import { UsersService } from '../users/users.service';
@@ -22,8 +18,14 @@ export class AuthService {
       ...dto,
       password: hashedPassword,
     });
-    const { password, ...result } = user;
-    return result;
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
   }
 
   async login(dto: LoginDto) {

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,0 +1,48 @@
+import {
+  ConflictException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcryptjs';
+import { UsersService } from '../users/users.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async register(dto: RegisterDto) {
+    const hashedPassword = await bcrypt.hash(dto.password, 10);
+    const user = await this.usersService.create({
+      ...dto,
+      password: hashedPassword,
+    });
+    const { password, ...result } = user;
+    return result;
+  }
+
+  async login(dto: LoginDto) {
+    const user = await this.usersService.findByEmail(dto.email);
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const isPasswordValid = await bcrypt.compare(dto.password, user.password);
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const payload = { sub: user.id, email: user.email, role: user.role };
+    const accessToken = await this.jwtService.signAsync(payload);
+    return { accessToken };
+  }
+
+  async validateUser(userId: string) {
+    return this.usersService.findOne(userId);
+  }
+}

--- a/apps/backend/src/auth/decorators/current-user.decorator.ts
+++ b/apps/backend/src/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/apps/backend/src/auth/decorators/current-user.decorator.ts
+++ b/apps/backend/src/auth/decorators/current-user.decorator.ts
@@ -1,8 +1,9 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
 
 export const CurrentUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
+    const request = ctx.switchToHttp().getRequest<Request>();
     return request.user;
   },
 );

--- a/apps/backend/src/auth/decorators/roles.decorator.ts
+++ b/apps/backend/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../../users/dto/create-user.dto';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/backend/src/auth/dto/login.dto.ts
+++ b/apps/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail({}, { message: 'Informe um e-mail válido' })
+  email: string;
+
+  @IsString({ message: 'A senha deve ser um texto válido' })
+  @IsNotEmpty({ message: 'A senha é obrigatória' })
+  password: string;
+}

--- a/apps/backend/src/auth/dto/register.dto.ts
+++ b/apps/backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,35 @@
+import {
+  IsString,
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  MinLength,
+  Matches,
+} from 'class-validator';
+import { Role } from '../../users/dto/create-user.dto';
+
+export class RegisterDto {
+  @IsString({ message: 'O nome deve ser um texto válido' })
+  @IsNotEmpty({ message: 'O nome é obrigatório' })
+  name: string;
+
+  @IsEmail({}, { message: 'Informe um e-mail válido' })
+  email: string;
+
+  @IsString({ message: 'A senha deve ser um texto válido' })
+  @IsNotEmpty({ message: 'A senha é obrigatória' })
+  @MinLength(8, { message: 'A senha deve ter no mínimo 8 caracteres' })
+  @Matches(/(?=.*[a-z])/, {
+    message: 'A senha deve conter pelo menos uma letra minúscula',
+  })
+  @Matches(/(?=.*[A-Z])/, {
+    message: 'A senha deve conter pelo menos uma letra maiúscula',
+  })
+  @Matches(/(?=.*\d)/, {
+    message: 'A senha deve conter pelo menos um número',
+  })
+  password: string;
+
+  @IsEnum(Role, { message: 'O cargo deve ser ARTIST ou CLIENT' })
+  role: Role;
+}

--- a/apps/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/backend/src/auth/guards/roles.guard.spec.ts
+++ b/apps/backend/src/auth/guards/roles.guard.spec.ts
@@ -1,4 +1,5 @@
 import { Reflector } from '@nestjs/core';
+import { ExecutionContext } from '@nestjs/common';
 import { RolesGuard } from './roles.guard';
 import { Role } from '../../users/dto/create-user.dto';
 
@@ -6,7 +7,7 @@ describe('RolesGuard', () => {
   let guard: RolesGuard;
   let reflector: Reflector;
 
-  const mockExecutionContext = (userRole?: string) => {
+  const mockExecutionContext = (userRole?: string): ExecutionContext => {
     const handler = () => {};
     return {
       switchToHttp: () => ({
@@ -16,7 +17,7 @@ describe('RolesGuard', () => {
       }),
       getHandler: handler,
       getClass: () => ({}),
-    } as any;
+    } as unknown as ExecutionContext;
   };
 
   beforeEach(() => {

--- a/apps/backend/src/auth/guards/roles.guard.spec.ts
+++ b/apps/backend/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,58 @@
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../../users/dto/create-user.dto';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  const mockExecutionContext = (userRole?: string) => {
+    const handler = () => {};
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: userRole ? { role: userRole } : undefined,
+        }),
+      }),
+      getHandler: handler,
+      getClass: () => ({}),
+    } as any;
+  };
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('should allow access when no roles are required', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+
+    const result = guard.canActivate(mockExecutionContext('CLIENT'));
+
+    expect(result).toBe(true);
+  });
+
+  it('should allow access when user has the required role', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue([Role.ARTIST]);
+
+    const result = guard.canActivate(mockExecutionContext('ARTIST'));
+
+    expect(result).toBe(true);
+  });
+
+  it('should deny access when user does not have the required role', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue([Role.ARTIST]);
+
+    const result = guard.canActivate(mockExecutionContext('CLIENT'));
+
+    expect(result).toBe(false);
+  });
+
+  it('should deny access when there is no user in request', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue([Role.ARTIST]);
+
+    const result = guard.canActivate(mockExecutionContext());
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/backend/src/auth/guards/roles.guard.ts
+++ b/apps/backend/src/auth/guards/roles.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { Role } from '../../users/dto/create-user.dto';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => user?.role === role);
+  }
+}

--- a/apps/backend/src/auth/guards/roles.guard.ts
+++ b/apps/backend/src/auth/guards/roles.guard.ts
@@ -2,6 +2,7 @@ import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ROLES_KEY } from '../decorators/roles.decorator';
 import { Role } from '../../users/dto/create-user.dto';
+import { Request } from 'express';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -17,7 +18,8 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    const { user } = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<Request>();
+    const user = request.user as { role: string } | undefined;
     return requiredRoles.some((role) => user?.role === role);
   }
 }

--- a/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,36 @@
+import { JwtStrategy } from './jwt.strategy';
+import { AuthService } from '../auth.service';
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+  let authService: AuthService;
+
+  const mockAuthService = {
+    validateUser: jest.fn(),
+  };
+
+  beforeEach(() => {
+    authService = mockAuthService as any;
+    strategy = new JwtStrategy(authService);
+  });
+
+  describe('validate', () => {
+    it('should return user object when payload is valid', async () => {
+      const payload = { sub: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
+      const user = { id: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
+      mockAuthService.validateUser.mockResolvedValue(user);
+
+      const result = await strategy.validate(payload);
+
+      expect(mockAuthService.validateUser).toHaveBeenCalledWith('uuid-1');
+      expect(result).toEqual(user);
+    });
+
+    it('should throw when user is not found', async () => {
+      const payload = { sub: 'nonexistent', email: 'test@test.com', role: 'CLIENT' };
+      mockAuthService.validateUser.mockResolvedValue(null);
+
+      await expect(strategy.validate(payload)).rejects.toThrow();
+    });
+  });
+});

--- a/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
@@ -8,6 +8,10 @@ describe('JwtStrategy', () => {
     validateUser: jest.fn(),
   };
 
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
   beforeEach(() => {
     strategy = new JwtStrategy(mockAuthService as AuthService);
   });

--- a/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
@@ -3,22 +3,20 @@ import { AuthService } from '../auth.service';
 
 describe('JwtStrategy', () => {
   let strategy: JwtStrategy;
-  let authService: AuthService;
 
-  const mockAuthService = {
+  const mockAuthService: Partial<AuthService> = {
     validateUser: jest.fn(),
   };
 
   beforeEach(() => {
-    authService = mockAuthService as any;
-    strategy = new JwtStrategy(authService);
+    strategy = new JwtStrategy(mockAuthService as AuthService);
   });
 
   describe('validate', () => {
     it('should return user object when payload is valid', async () => {
       const payload = { sub: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
       const user = { id: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
-      mockAuthService.validateUser.mockResolvedValue(user);
+      (mockAuthService.validateUser as jest.Mock).mockResolvedValue(user);
 
       const result = await strategy.validate(payload);
 
@@ -27,8 +25,12 @@ describe('JwtStrategy', () => {
     });
 
     it('should throw when user is not found', async () => {
-      const payload = { sub: 'nonexistent', email: 'test@test.com', role: 'CLIENT' };
-      mockAuthService.validateUser.mockResolvedValue(null);
+      const payload = {
+        sub: 'nonexistent',
+        email: 'test@test.com',
+        role: 'CLIENT',
+      };
+      (mockAuthService.validateUser as jest.Mock).mockResolvedValue(null);
 
       await expect(strategy.validate(payload)).rejects.toThrow();
     });

--- a/apps/backend/src/auth/strategies/jwt.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,23 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly authService: AuthService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET,
+    });
+  }
+
+  async validate(payload: { sub: string; email: string; role: string }) {
+    const user = await this.authService.validateUser(payload.sub);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+    return user;
+  }
+}

--- a/apps/backend/src/commissions/commissions.controller.spec.ts
+++ b/apps/backend/src/commissions/commissions.controller.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
 import { CommissionsController } from './commissions.controller';
 import { CommissionsService } from './commissions.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../users/dto/create-user.dto';
 
 describe('CommissionsController', () => {
   let controller: CommissionsController;
@@ -13,11 +17,19 @@ describe('CommissionsController', () => {
     remove: jest.fn(),
   };
 
+  const mockJwtGuard = { canActivate: jest.fn(() => true) };
+  const mockRolesGuard = { canActivate: jest.fn(() => true) };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CommissionsController],
       providers: [{ provide: CommissionsService, useValue: mockService }],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtGuard)
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
+      .compile();
 
     controller = module.get<CommissionsController>(CommissionsController);
   });
@@ -46,21 +58,39 @@ describe('CommissionsController', () => {
   });
 
   describe('findAll', () => {
-    it('should return all commissions', async () => {
+    it('should return all commissions for authenticated user', async () => {
+      const user = { id: 'artist-uuid', role: Role.ARTIST };
+      const req = { user };
       const expected = [{ id: 'uuid-1', title: 'Portrait' }];
       mockService.findAll.mockResolvedValue(expected);
 
-      const result = await controller.findAll();
+      const result = await controller.findAll(req as unknown as Request);
+
+      expect(mockService.findAll).toHaveBeenCalledWith(
+        'artist-uuid',
+        Role.ARTIST,
+      );
       expect(result).toEqual(expected);
     });
   });
 
   describe('findOne', () => {
     it('should return a commission by id', async () => {
+      const user = { id: 'client-uuid', role: Role.CLIENT };
+      const req = { user };
       const expected = { id: 'uuid-1', title: 'Portrait' };
       mockService.findOne.mockResolvedValue(expected);
 
-      const result = await controller.findOne('uuid-1');
+      const result = await controller.findOne(
+        req as unknown as Request,
+        'uuid-1',
+      );
+
+      expect(mockService.findOne).toHaveBeenCalledWith(
+        'uuid-1',
+        'client-uuid',
+        Role.CLIENT,
+      );
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/commissions/commissions.controller.ts
+++ b/apps/backend/src/commissions/commissions.controller.ts
@@ -6,35 +6,51 @@ import {
   Delete,
   Param,
   Body,
+  Req,
+  UseGuards,
 } from '@nestjs/common';
 import { CommissionsService } from './commissions.service';
 import { CreateCommissionDto } from './dto/create-commission.dto';
 import { UpdateCommissionDto } from './dto/update-commission.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../users/dto/create-user.dto';
+import { Request } from 'express';
 
+@UseGuards(JwtAuthGuard)
 @Controller('commissions')
 export class CommissionsController {
   constructor(private readonly commissionsService: CommissionsService) {}
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.ARTIST)
   @Post()
   create(@Body() dto: CreateCommissionDto) {
     return this.commissionsService.create(dto);
   }
 
   @Get()
-  findAll() {
-    return this.commissionsService.findAll();
+  findAll(@Req() req: Request) {
+    const user = req.user as { id: string; role: string };
+    return this.commissionsService.findAll(user.id, user.role);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.commissionsService.findOne(id);
+  findOne(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as { id: string; role: string };
+    return this.commissionsService.findOne(id, user.id, user.role);
   }
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.ARTIST)
   @Patch(':id')
   update(@Param('id') id: string, @Body() dto: UpdateCommissionDto) {
     return this.commissionsService.update(id, dto);
   }
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.ARTIST)
   @Delete(':id')
   async remove(@Param('id') id: string) {
     await this.commissionsService.remove(id);

--- a/apps/backend/src/commissions/commissions.service.spec.ts
+++ b/apps/backend/src/commissions/commissions.service.spec.ts
@@ -64,29 +64,72 @@ describe('CommissionsService', () => {
   });
 
   describe('findAll', () => {
-    it('should return all commissions', async () => {
+    it('should return all commissions for ARTIST', async () => {
       const expected = [{ id: 'uuid-1', title: 'Portrait' }];
       mockPrisma.commission.findMany.mockResolvedValue(expected);
 
-      const result = await service.findAll();
+      const result = await service.findAll('artist-uuid', 'ARTIST');
+
+      expect(mockPrisma.commission.findMany).toHaveBeenCalledWith();
+      expect(result).toEqual(expected);
+    });
+
+    it('should return only own commissions for CLIENT', async () => {
+      const expected = [
+        { id: 'uuid-1', title: 'Portrait', clientId: 'client-uuid' },
+      ];
+      mockPrisma.commission.findMany.mockResolvedValue(expected);
+
+      const result = await service.findAll('client-uuid', 'CLIENT');
+
+      expect(mockPrisma.commission.findMany).toHaveBeenCalledWith({
+        where: { clientId: 'client-uuid' },
+      });
       expect(result).toEqual(expected);
     });
   });
 
   describe('findOne', () => {
-    it('should return a commission by id', async () => {
+    it('should return a commission by id for ARTIST', async () => {
       const expected = { id: 'uuid-1', title: 'Portrait' };
       mockPrisma.commission.findUnique.mockResolvedValue(expected);
 
-      const result = await service.findOne('uuid-1');
+      const result = await service.findOne('uuid-1', 'artist-uuid', 'ARTIST');
+
       expect(result).toEqual(expected);
+    });
+
+    it('should return a commission by id for CLIENT owner', async () => {
+      const expected = {
+        id: 'uuid-1',
+        title: 'Portrait',
+        clientId: 'client-uuid',
+      };
+      mockPrisma.commission.findUnique.mockResolvedValue(expected);
+
+      const result = await service.findOne('uuid-1', 'client-uuid', 'CLIENT');
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw NotFoundException when CLIENT tries to access another commission', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        title: 'Portrait',
+        clientId: 'other-client',
+      });
+
+      await expect(
+        service.findOne('uuid-1', 'client-uuid', 'CLIENT'),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('should throw NotFoundException when commission not found', async () => {
       mockPrisma.commission.findUnique.mockResolvedValue(null);
-      await expect(service.findOne('nonexistent')).rejects.toThrow(
-        NotFoundException,
-      );
+
+      await expect(
+        service.findOne('nonexistent', 'any-id', 'ARTIST'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/apps/backend/src/commissions/commissions.service.ts
+++ b/apps/backend/src/commissions/commissions.service.ts
@@ -25,15 +25,20 @@ export class CommissionsService {
     return this.prisma.commission.create({ data: dto });
   }
 
-  async findAll() {
+  async findAll(userId: string, role: string) {
+    if (role === 'CLIENT') {
+      return this.prisma.commission.findMany({
+        where: { clientId: userId },
+      });
+    }
     return this.prisma.commission.findMany();
   }
 
-  async findOne(id: string) {
-    const commission = await this.prisma.commission.findUnique({
-      where: { id },
-    });
-    if (!commission) throw new NotFoundException('Commission not found');
+  async findOne(id: string, userId: string, role: string) {
+    const commission = await this.findById(id);
+    if (role === 'CLIENT' && commission.clientId !== userId) {
+      throw new NotFoundException('Commission not found');
+    }
     return commission;
   }
 
@@ -41,12 +46,20 @@ export class CommissionsService {
     id: string,
     dto: Partial<{ title: string; description: string; price: number }>,
   ) {
-    await this.findOne(id);
+    await this.findById(id);
     return this.prisma.commission.update({ where: { id }, data: dto });
   }
 
   async remove(id: string) {
-    await this.findOne(id);
+    await this.findById(id);
     await this.prisma.commission.delete({ where: { id } });
+  }
+
+  private async findById(id: string) {
+    const commission = await this.prisma.commission.findUnique({
+      where: { id },
+    });
+    if (!commission) throw new NotFoundException('Commission not found');
+    return commission;
   }
 }

--- a/apps/backend/src/deliveries/deliveries.controller.spec.ts
+++ b/apps/backend/src/deliveries/deliveries.controller.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
 import { DeliveriesController } from './deliveries.controller';
 import { DeliveriesService } from './deliveries.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Role } from '../users/dto/create-user.dto';
 
 describe('DeliveriesController', () => {
   let controller: DeliveriesController;
@@ -10,11 +14,19 @@ describe('DeliveriesController', () => {
     findByCommission: jest.fn(),
   };
 
+  const mockJwtGuard = { canActivate: jest.fn(() => true) };
+  const mockRolesGuard = { canActivate: jest.fn(() => true) };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DeliveriesController],
       providers: [{ provide: DeliveriesService, useValue: mockService }],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtGuard)
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
+      .compile();
 
     controller = module.get<DeliveriesController>(DeliveriesController);
   });
@@ -42,10 +54,21 @@ describe('DeliveriesController', () => {
 
   describe('findByCommission', () => {
     it('should return deliveries for a commission', async () => {
+      const user = { id: 'client-uuid', role: Role.CLIENT };
+      const req = { user };
       const expected = [{ id: 'uuid-1', fileUrl: 'https://cdn.com/art.png' }];
       mockService.findByCommission.mockResolvedValue(expected);
 
-      const result = await controller.findByCommission('comm-uuid');
+      const result = await controller.findByCommission(
+        req as unknown as Request,
+        'comm-uuid',
+      );
+
+      expect(mockService.findByCommission).toHaveBeenCalledWith(
+        'comm-uuid',
+        'client-uuid',
+        Role.CLIENT,
+      );
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/deliveries/deliveries.controller.ts
+++ b/apps/backend/src/deliveries/deliveries.controller.ts
@@ -1,18 +1,42 @@
-import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { DeliveriesService } from './deliveries.service';
 import { CreateDeliveryDto } from './dto/create-delivery.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../users/dto/create-user.dto';
+import { Request } from 'express';
 
+@UseGuards(JwtAuthGuard)
 @Controller('deliveries')
 export class DeliveriesController {
   constructor(private readonly deliveriesService: DeliveriesService) {}
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.ARTIST)
   @Post()
   create(@Body() dto: CreateDeliveryDto) {
     return this.deliveriesService.create(dto);
   }
 
   @Get(':commissionId')
-  findByCommission(@Param('commissionId') commissionId: string) {
-    return this.deliveriesService.findByCommission(commissionId);
+  findByCommission(
+    @Req() req: Request,
+    @Param('commissionId') commissionId: string,
+  ) {
+    const user = req.user as { id: string; role: string };
+    return this.deliveriesService.findByCommission(
+      commissionId,
+      user.id,
+      user.role,
+    );
   }
 }

--- a/apps/backend/src/deliveries/deliveries.service.spec.ts
+++ b/apps/backend/src/deliveries/deliveries.service.spec.ts
@@ -53,15 +53,60 @@ describe('DeliveriesService', () => {
   });
 
   describe('findByCommission', () => {
-    it('should return deliveries for a commission', async () => {
+    it('should return deliveries for ARTIST', async () => {
       const expected = [{ id: 'uuid-1', fileUrl: 'https://cdn.com/art.png' }];
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'comm-uuid',
+        clientId: 'client-uuid',
+      });
       mockPrisma.delivery.findMany.mockResolvedValue(expected);
 
-      const result = await service.findByCommission('comm-uuid');
-      expect(result).toEqual(expected);
+      const result = await service.findByCommission(
+        'comm-uuid',
+        'artist-uuid',
+        'ARTIST',
+      );
+
       expect(mockPrisma.delivery.findMany).toHaveBeenCalledWith({
         where: { commissionId: 'comm-uuid' },
       });
+      expect(result).toEqual(expected);
+    });
+
+    it('should return deliveries for CLIENT owner', async () => {
+      const expected = [{ id: 'uuid-1', fileUrl: 'https://cdn.com/art.png' }];
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'comm-uuid',
+        clientId: 'client-uuid',
+      });
+      mockPrisma.delivery.findMany.mockResolvedValue(expected);
+
+      const result = await service.findByCommission(
+        'comm-uuid',
+        'client-uuid',
+        'CLIENT',
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw NotFoundException for CLIENT not owning the commission', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'comm-uuid',
+        clientId: 'other-client',
+      });
+
+      await expect(
+        service.findByCommission('comm-uuid', 'client-uuid', 'CLIENT'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when commission does not exist', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.findByCommission('comm-uuid', 'any-id', 'ARTIST'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/backend/src/deliveries/deliveries.service.ts
+++ b/apps/backend/src/deliveries/deliveries.service.ts
@@ -14,7 +14,16 @@ export class DeliveriesService {
     return this.prisma.delivery.create({ data: dto });
   }
 
-  async findByCommission(commissionId: string) {
+  async findByCommission(commissionId: string, userId: string, role: string) {
+    const commission = await this.prisma.commission.findUnique({
+      where: { id: commissionId },
+    });
+    if (!commission) throw new NotFoundException('Commission not found');
+
+    if (role === 'CLIENT' && commission.clientId !== userId) {
+      throw new NotFoundException('Commission not found');
+    }
+
     return this.prisma.delivery.findMany({ where: { commissionId } });
   }
 }

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -13,11 +15,16 @@ describe('UsersController', () => {
     remove: jest.fn(),
   };
 
+  const mockGuard = { canActivate: jest.fn(() => true) };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
       providers: [{ provide: UsersService, useValue: mockService }],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockGuard)
+      .compile();
 
     controller = module.get<UsersController>(UsersController);
   });
@@ -62,6 +69,20 @@ describe('UsersController', () => {
 
       const result = await controller.findOne('uuid-1');
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('me', () => {
+    it('should return the current user from request', () => {
+      const user = {
+        id: 'uuid-1',
+        name: 'John',
+        email: 'john@test.com',
+        role: 'CLIENT',
+      };
+      const req = { user };
+      const result = controller.getProfile(req as unknown as Request);
+      expect(result).toEqual(user);
     });
   });
 

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -6,10 +6,14 @@ import {
   Delete,
   Param,
   Body,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Request } from 'express';
 
 @Controller('users')
 export class UsersController {
@@ -20,21 +24,31 @@ export class UsersController {
     return this.usersService.create(dto);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  getProfile(@Req() req: Request) {
+    return req.user;
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get()
   findAll() {
     return this.usersService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.usersService.findOne(id);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
     return this.usersService.update(id, dto);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Delete(':id')
   async remove(@Param('id') id: string) {
     await this.usersService.remove(id);

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -29,6 +29,10 @@ export class UsersService {
     return this.prisma.user.findMany();
   }
 
+  async findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+
   async findOne(id: string) {
     const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) throw new NotFoundException('User not found');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,18 @@
       "license": "UNLICENSED",
       "workspaces": [
         "apps/*"
-      ]
+      ],
+      "dependencies": {
+        "@nestjs/jwt": "^11.0.2",
+        "@nestjs/passport": "^11.0.5",
+        "bcryptjs": "^3.0.3",
+        "passport": "^0.7.0",
+        "passport-jwt": "^4.0.1"
+      },
+      "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/passport-jwt": "^4.0.1"
+      }
     },
     "apps/backend": {
       "version": "0.0.1",
@@ -2573,6 +2584,29 @@
         }
       }
     },
+    "node_modules/@nestjs/jwt": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz",
+      "integrity": "sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "9.0.10",
+        "jsonwebtoken": "9.0.3"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/passport": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
+      "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.19",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
@@ -3509,6 +3543,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3651,6 +3692,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3658,15 +3709,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4919,6 +5007,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/better-result": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.2.tgz",
@@ -5069,6 +5166,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5321,15 +5424,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5889,6 +5990,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8583,6 +8693,61 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8946,6 +9111,42 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8958,6 +9159,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -9653,6 +9860,43 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9734,6 +9978,11 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
@@ -11680,7 +11929,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -11783,6 +12031,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,22 @@
     "dev:api": "npm run start:dev -w apps/backend",
     "dev:web": "npm run start:dev -w apps/frontend"
   },
-  "keywords": ["nestjs", "react", "monorepo"],
+  "keywords": [
+    "nestjs",
+    "react",
+    "monorepo"
+  ],
   "author": "Diogo Nery de Abreu",
-  "license": "UNLICENSED"
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@nestjs/jwt": "^11.0.2",
+    "@nestjs/passport": "^11.0.5",
+    "bcryptjs": "^3.0.3",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/passport-jwt": "^4.0.1"
+  }
 }


### PR DESCRIPTION
## O que foi implementado (ID8)

### Autenticação JWT
- `POST /auth/register` — cadastro com hash bcryptjs + validação forte de senha
- `POST /auth/login` — retorna `{ accessToken }` (JWT com expiração de 7d)
- `JwtStrategy` — extrai token do header Bearer, valida payload

### Controle de Acesso
- `JwtAuthGuard` — protege rotas autenticadas
- `RolesGuard` + `@Roles()` — restringe endpoints por perfil (ARTIST/CLIENT)
- `@CurrentUser()` — decorator para acessar usuário autenticado

### Ownership Validation
- CLIENT só visualiza próprias comissões e deliveries
- ARTIST tem visão completa

### Endpoints protegidos

| Rota | Acesso |
|---|---|
| `POST /auth/register` | Público |
| `POST /auth/login` | Público |
| `GET /users/me` | Autenticado |
| `POST /commissions` | ARTIST |
| `PATCH /commissions/:id` | ARTIST |
| `DELETE /commissions/:id` | ARTIST |
| `POST /deliveries` | ARTIST |
| Demais GETs | Autenticado (com ownership filter) |

### Commits
- `f337e17` — feat: add JWT auth module with register, login, guards and strategies
- `691db29` — feat: protect endpoints with JWT auth, role guards and ownership (ID8)

### Testes
- 60 testes unitários passando (11 suites)
- Cobertura: auth service, auth controller, roles guard, jwt strategy, ownership nos services