### PR TITLE
fix: correções de segurança e Swagger (ID12)

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.4",
     "@prisma/adapter-neon": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "class-transformer": "^0.5.1",

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,18 +1,26 @@
 import { Controller, Post, Body } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({ summary: 'Registrar novo usuário' })
+  @ApiResponse({ status: 201, description: 'Usuário criado com sucesso.' })
+  @ApiResponse({ status: 409, description: 'Email já cadastrado.' })
   register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'Autenticar usuário' })
+  @ApiResponse({ status: 200, description: 'Token JWT gerado com sucesso.' })
+  @ApiResponse({ status: 401, description: 'Credenciais inválidas.' })
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
   }

--- a/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.spec.ts
@@ -17,15 +17,25 @@ describe('JwtStrategy', () => {
   });
 
   describe('validate', () => {
-    it('should return user object when payload is valid', async () => {
+    it('should return user without password when payload is valid', async () => {
       const payload = { sub: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
-      const user = { id: 'uuid-1', email: 'john@test.com', role: 'CLIENT' };
+      const user = {
+        id: 'uuid-1',
+        email: 'john@test.com',
+        role: 'CLIENT',
+        password: '$2a$10$hashhash',
+      };
       (mockAuthService.validateUser as jest.Mock).mockResolvedValue(user);
 
       const result = await strategy.validate(payload);
 
       expect(mockAuthService.validateUser).toHaveBeenCalledWith('uuid-1');
-      expect(result).toEqual(user);
+      expect(result).toEqual({
+        id: 'uuid-1',
+        email: 'john@test.com',
+        role: 'CLIENT',
+      });
+      expect(result).not.toHaveProperty('password');
     });
 
     it('should throw when user is not found', async () => {

--- a/apps/backend/src/auth/strategies/jwt.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt.strategy.ts
@@ -9,7 +9,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET,
+      secretOrKey: process.env.JWT_SECRET!,
     });
   }
 
@@ -18,6 +18,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException();
     }
-    return user;
+    const publicUser = { ...user };
+    delete (publicUser as { password?: string }).password;
+    return publicUser;
   }
 }

--- a/apps/backend/src/commissions/commissions.controller.spec.ts
+++ b/apps/backend/src/commissions/commissions.controller.spec.ts
@@ -41,18 +41,21 @@ describe('CommissionsController', () => {
   });
 
   describe('create', () => {
-    it('should call service.create with DTO', async () => {
+    it('should call service.create with DTO and authenticated artist', async () => {
+      const user = { id: 'artist-uuid' };
+      const req = { user };
       const dto = {
         title: 'Portrait',
         description: 'Art',
         price: 150,
         clientId: 'c1',
-        artistId: 'a1',
       };
-      const expected = { id: 'uuid-1', ...dto };
+      const expected = { id: 'uuid-1', ...dto, artistId: 'artist-uuid' };
       mockService.create.mockResolvedValue(expected);
 
-      const result = await controller.create(dto);
+      const result = await controller.create(req as unknown as Request, dto);
+
+      expect(mockService.create).toHaveBeenCalledWith(dto, 'artist-uuid');
       expect(result).toEqual(expected);
     });
   });
@@ -96,20 +99,37 @@ describe('CommissionsController', () => {
   });
 
   describe('update', () => {
-    it('should update a commission', async () => {
+    it('should call service.update with DTO and userId', async () => {
+      const user = { id: 'artist-uuid' };
+      const req = { user };
       const dto = { title: 'Updated' };
       const expected = { id: 'uuid-1', title: 'Updated' };
       mockService.update.mockResolvedValue(expected);
 
-      const result = await controller.update('uuid-1', dto);
+      const result = await controller.update(
+        req as unknown as Request,
+        'uuid-1',
+        dto,
+      );
+
+      expect(mockService.update).toHaveBeenCalledWith(
+        'uuid-1',
+        dto,
+        'artist-uuid',
+      );
       expect(result).toEqual(expected);
     });
   });
 
   describe('remove', () => {
-    it('should delete a commission', async () => {
-      await controller.remove('uuid-1');
-      expect(mockService.remove).toHaveBeenCalledWith('uuid-1');
+    it('should call service.remove with id and userId', async () => {
+      const user = { id: 'artist-uuid' };
+      const req = { user };
+      mockService.remove.mockResolvedValue(undefined);
+
+      await controller.remove(req as unknown as Request, 'uuid-1');
+
+      expect(mockService.remove).toHaveBeenCalledWith('uuid-1', 'artist-uuid');
     });
   });
 });

--- a/apps/backend/src/commissions/commissions.controller.ts
+++ b/apps/backend/src/commissions/commissions.controller.ts
@@ -9,6 +9,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { CommissionsService } from './commissions.service';
 import { CreateCommissionDto } from './dto/create-commission.dto';
 import { UpdateCommissionDto } from './dto/update-commission.dto';
@@ -16,8 +17,10 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { Role } from '../users/dto/create-user.dto';
-import { Request } from 'express';
+import type { Request } from 'express';
 
+@ApiTags('Commissions')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('commissions')
 export class CommissionsController {
@@ -26,8 +29,9 @@ export class CommissionsController {
   @UseGuards(RolesGuard)
   @Roles(Role.ARTIST)
   @Post()
-  create(@Body() dto: CreateCommissionDto) {
-    return this.commissionsService.create(dto);
+  create(@Req() req: Request, @Body() dto: CreateCommissionDto) {
+    const user = req.user as { id: string };
+    return this.commissionsService.create(dto, user.id);
   }
 
   @Get()
@@ -45,14 +49,20 @@ export class CommissionsController {
   @UseGuards(RolesGuard)
   @Roles(Role.ARTIST)
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateCommissionDto) {
-    return this.commissionsService.update(id, dto);
+  update(
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Body() dto: UpdateCommissionDto,
+  ) {
+    const user = req.user as { id: string };
+    return this.commissionsService.update(id, dto, user.id);
   }
 
   @UseGuards(RolesGuard)
   @Roles(Role.ARTIST)
   @Delete(':id')
-  async remove(@Param('id') id: string) {
-    await this.commissionsService.remove(id);
+  async remove(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as { id: string };
+    await this.commissionsService.remove(id, user.id);
   }
 }

--- a/apps/backend/src/commissions/commissions.service.spec.ts
+++ b/apps/backend/src/commissions/commissions.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { CommissionsService } from './commissions.service';
 import { PrismaService } from '../prisma/prisma.service';
 
@@ -38,28 +38,32 @@ describe('CommissionsService', () => {
       description: 'Digital art',
       price: 150,
       clientId: 'client-uuid',
-      artistId: 'artist-uuid',
     };
+    const artistId = 'artist-uuid';
 
     it('should create a commission', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ id: 'client-uuid' });
       mockPrisma.user.findUnique.mockResolvedValueOnce({ id: 'artist-uuid' });
-      const expected = { id: 'uuid-1', ...dto, status: 'PENDING' };
+      const expected = { id: 'uuid-1', ...dto, artistId, status: 'PENDING' };
       mockPrisma.commission.create.mockResolvedValue(expected);
 
-      const result = await service.create(dto);
+      const result = await service.create(dto, artistId);
       expect(result).toEqual(expected);
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      await expect(service.create(dto)).rejects.toThrow(NotFoundException);
+      await expect(service.create(dto, artistId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('should throw NotFoundException when artist does not exist', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ id: 'client-uuid' });
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
-      await expect(service.create(dto)).rejects.toThrow(NotFoundException);
+      await expect(service.create(dto, artistId)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -135,35 +139,66 @@ describe('CommissionsService', () => {
 
   describe('update', () => {
     const dto = { title: 'Updated' };
+    const userId = 'artist-uuid';
 
-    it('should update a commission', async () => {
-      mockPrisma.commission.findUnique.mockResolvedValue({ id: 'uuid-1' });
+    it('should update a commission when artist is the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'artist-uuid',
+      });
       const updated = { id: 'uuid-1', title: 'Updated' };
       mockPrisma.commission.update.mockResolvedValue(updated);
 
-      const result = await service.update('uuid-1', dto);
+      const result = await service.update('uuid-1', dto, userId);
       expect(result).toEqual(updated);
+    });
+
+    it('should throw ForbiddenException when artist is not the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'other-artist',
+      });
+
+      await expect(service.update('uuid-1', dto, userId)).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('should throw NotFoundException if commission does not exist', async () => {
       mockPrisma.commission.findUnique.mockResolvedValue(null);
-      await expect(service.update('nonexistent', dto)).rejects.toThrow(
+      await expect(service.update('nonexistent', dto, userId)).rejects.toThrow(
         NotFoundException,
       );
     });
   });
 
   describe('remove', () => {
-    it('should delete a commission', async () => {
-      mockPrisma.commission.findUnique.mockResolvedValue({ id: 'uuid-1' });
+    const userId = 'artist-uuid';
+
+    it('should delete a commission when artist is the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'artist-uuid',
+      });
       mockPrisma.commission.delete.mockResolvedValue({ id: 'uuid-1' });
 
-      await expect(service.remove('uuid-1')).resolves.toBeUndefined();
+      await expect(service.remove('uuid-1', userId)).resolves.toBeUndefined();
+    });
+
+    it('should throw ForbiddenException when artist is not the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'other-artist',
+      });
+
+      await expect(service.remove('uuid-1', userId)).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('should throw NotFoundException if commission does not exist', async () => {
       mockPrisma.commission.findUnique.mockResolvedValue(null);
-      await expect(service.remove('nonexistent')).rejects.toThrow(
+      await expect(service.remove('nonexistent', userId)).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/apps/backend/src/commissions/commissions.service.ts
+++ b/apps/backend/src/commissions/commissions.service.ts
@@ -1,28 +1,34 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class CommissionsService {
   constructor(private prisma: PrismaService) {}
 
-  async create(dto: {
-    title: string;
-    description: string;
-    price: number;
-    clientId: string;
-    artistId: string;
-  }) {
+  async create(
+    dto: {
+      title: string;
+      description: string;
+      price: number;
+      clientId: string;
+    },
+    artistId: string,
+  ) {
     const client = await this.prisma.user.findUnique({
       where: { id: dto.clientId },
     });
     if (!client) throw new NotFoundException('Client not found');
 
     const artist = await this.prisma.user.findUnique({
-      where: { id: dto.artistId },
+      where: { id: artistId },
     });
     if (!artist) throw new NotFoundException('Artist not found');
 
-    return this.prisma.commission.create({ data: dto });
+    return this.prisma.commission.create({ data: { ...dto, artistId } });
   }
 
   async findAll(userId: string, role: string) {
@@ -45,13 +51,20 @@ export class CommissionsService {
   async update(
     id: string,
     dto: Partial<{ title: string; description: string; price: number }>,
+    userId: string,
   ) {
-    await this.findById(id);
+    const commission = await this.findById(id);
+    if (commission.artistId !== userId) {
+      throw new ForbiddenException('You can only update your own commissions');
+    }
     return this.prisma.commission.update({ where: { id }, data: dto });
   }
 
-  async remove(id: string) {
-    await this.findById(id);
+  async remove(id: string, userId: string) {
+    const commission = await this.findById(id);
+    if (commission.artistId !== userId) {
+      throw new ForbiddenException('You can only delete your own commissions');
+    }
     await this.prisma.commission.delete({ where: { id } });
   }
 

--- a/apps/backend/src/commissions/dto/create-commission.dto.ts
+++ b/apps/backend/src/commissions/dto/create-commission.dto.ts
@@ -27,8 +27,4 @@ export class CreateCommissionDto {
   @IsString({ message: 'O ID do cliente deve ser um texto válido' })
   @IsNotEmpty({ message: 'O ID do cliente é obrigatório' })
   clientId: string;
-
-  @IsString({ message: 'O ID do artista deve ser um texto válido' })
-  @IsNotEmpty({ message: 'O ID do artista é obrigatório' })
-  artistId: string;
 }

--- a/apps/backend/src/deliveries/deliveries.controller.ts
+++ b/apps/backend/src/deliveries/deliveries.controller.ts
@@ -7,14 +7,17 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { DeliveriesService } from './deliveries.service';
 import { CreateDeliveryDto } from './dto/create-delivery.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { Role } from '../users/dto/create-user.dto';
-import { Request } from 'express';
+import type { Request } from 'express';
 
+@ApiTags('Deliveries')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('deliveries')
 export class DeliveriesController {

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
@@ -8,7 +9,17 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.enableCors();
-  app.setGlobalPrefix('api/v1');
+  app.setGlobalPrefix('api/v1', { exclude: ['api/docs'] });
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('CommissionTrack API')
+    .setDescription('Sistema de Gerenciamento de Comissões Artísticas')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, document);
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -35,23 +35,6 @@ describe('UsersController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('create', () => {
-    it('should call service.create with DTO', async () => {
-      const dto = {
-        name: 'John',
-        email: 'john@test.com',
-        password: '123456',
-        role: 'CLIENT' as const,
-      };
-      const expected = { id: 'uuid-1', ...dto };
-      mockService.create.mockResolvedValue(expected);
-
-      const result = await controller.create(dto);
-      expect(result).toEqual(expected);
-      expect(mockService.create).toHaveBeenCalledWith(dto);
-    });
-  });
-
   describe('findAll', () => {
     it('should return all users', async () => {
       const expected = [{ id: 'uuid-1', name: 'John' }];

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -1,28 +1,24 @@
 import {
   Controller,
   Get,
-  Post,
+  Body,
   Patch,
   Delete,
   Param,
-  Body,
-  UseGuards,
   Req,
+  UseGuards,
 } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
-import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { Request } from 'express';
+import type { Request } from 'express';
 
+@ApiTags('Users')
+@ApiBearerAuth()
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
-
-  @Post()
-  create(@Body() dto: CreateUserDto) {
-    return this.usersService.create(dto);
-  }
 
   @UseGuards(JwtAuthGuard)
   @Get('me')

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -1,7 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
 import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn().mockResolvedValue('$2a$10$hashed_password'),
+}));
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -118,14 +123,37 @@ describe('UsersService', () => {
         service.update('uuid-1', { email: 'taken@test.com' }),
       ).rejects.toThrow(ConflictException);
     });
+
+    it('should hash password when provided', async () => {
+      const existing = { id: 'uuid-1', name: 'John' };
+      mockPrisma.user.findUnique.mockResolvedValue(existing);
+      const updated = {
+        id: 'uuid-1',
+        name: 'John',
+        password: '$2a$10$hashed_password',
+      };
+      mockPrisma.user.update.mockResolvedValue(updated);
+
+      const result = await service.update('uuid-1', {
+        password: 'new-password',
+      });
+
+      expect(bcrypt.hash).toHaveBeenCalledWith('new-password', 10);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'uuid-1' },
+        data: { password: '$2a$10$hashed_password' },
+      });
+      expect(result).toEqual(updated);
+    });
   });
 
   describe('remove', () => {
-    it('should delete a user', async () => {
+    it('should delete a user and return it', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({ id: 'uuid-1' });
       mockPrisma.user.delete.mockResolvedValue({ id: 'uuid-1' });
 
-      await expect(service.remove('uuid-1')).resolves.toBeUndefined();
+      const result = await service.remove('uuid-1');
+      expect(result).toEqual({ id: 'uuid-1' });
     });
 
     it('should throw NotFoundException if user does not exist', async () => {

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -49,6 +50,9 @@ export class UsersService {
     }>,
   ) {
     await this.findOne(id);
+    if (dto.password) {
+      dto.password = await bcrypt.hash(dto.password, 10);
+    }
     try {
       return await this.prisma.user.update({ where: { id }, data: dto });
     } catch (error) {
@@ -61,6 +65,6 @@ export class UsersService {
 
   async remove(id: string) {
     await this.findOne(id);
-    await this.prisma.user.delete({ where: { id } });
+    return await this.prisma.user.delete({ where: { id } });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.4.4",
         "@prisma/adapter-neon": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "class-transformer": "^0.5.1",
@@ -2256,6 +2257,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2597,6 +2604,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -2648,6 +2675,39 @@
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
+      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.6"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -3402,6 +3462,13 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -4827,7 +4894,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -5424,13 +5490,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8610,7 +8678,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11233,6 +11300,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {


### PR DESCRIPTION
## O que foi feito

### Correções Críticas
- **Removido `POST /users`**: endpoint público que armazenava senha em texto puro (redundante com `POST /auth/register`)
- **`GET /users/me`**: não vaza mais o hash da senha — `JwtStrategy` remove `password` antes de anexar ao `req.user`
- **`PATCH /users/:id`**: senha agora é hasheada com bcryptjs antes de persistir

### Correções de Alta Prioridade
- **`DELETE /users/:id`**: agora retorna o usuário deletado (antes retornava `undefined`)
- **`POST /commissions`**: `artistId` agora vem do token JWT (`req.user.id`), não mais do body da requisição — removido do `CreateCommissionDto`
- **`PATCH/DELETE /commissions/:id`**: adicionada verificação de ownership — apenas o ARTIST dono da comissão pode alterá-la ou excluí-la

### Swagger (ID12)
- Instalado `@nestjs/swagger` + plugin automático no `nest-cli.json`
- Configurado `DocumentBuilder` com BearerAuth
- Rota: `GET /api/docs` (fora do prefixo `api/v1`)
- `@ApiTags` em todos os controllers, `@ApiOperation`/`@ApiResponse` no AuthController

### Resultado
- ✅ 62 testes unitários passando
- ✅ Lint limpo
- ✅ Build compila sem erros