### PR TITLE
fix: permissões de users, endpoint de status e checklist

### DIFF
--- a/apps/backend/src/commissions/commissions.controller.spec.ts
+++ b/apps/backend/src/commissions/commissions.controller.spec.ts
@@ -14,6 +14,7 @@ describe('CommissionsController', () => {
     findAll: jest.fn(),
     findOne: jest.fn(),
     update: jest.fn(),
+    updateStatus: jest.fn(),
     remove: jest.fn(),
   };
 
@@ -115,6 +116,29 @@ describe('CommissionsController', () => {
       expect(mockService.update).toHaveBeenCalledWith(
         'uuid-1',
         dto,
+        'artist-uuid',
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should call service.updateStatus with status and userId', async () => {
+      const user = { id: 'artist-uuid' };
+      const req = { user };
+      const dto = { status: 'IN_PROGRESS' };
+      const expected = { id: 'uuid-1', status: 'IN_PROGRESS' };
+      mockService.updateStatus.mockResolvedValue(expected);
+
+      const result = await controller.updateStatus(
+        req as unknown as Request,
+        'uuid-1',
+        dto,
+      );
+
+      expect(mockService.updateStatus).toHaveBeenCalledWith(
+        'uuid-1',
+        'IN_PROGRESS',
         'artist-uuid',
       );
       expect(result).toEqual(expected);

--- a/apps/backend/src/commissions/commissions.controller.ts
+++ b/apps/backend/src/commissions/commissions.controller.ts
@@ -13,6 +13,7 @@ import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { CommissionsService } from './commissions.service';
 import { CreateCommissionDto } from './dto/create-commission.dto';
 import { UpdateCommissionDto } from './dto/update-commission.dto';
+import { UpdateCommissionStatusDto } from './dto/update-commission-status.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -56,6 +57,18 @@ export class CommissionsController {
   ) {
     const user = req.user as { id: string };
     return this.commissionsService.update(id, dto, user.id);
+  }
+
+  @UseGuards(RolesGuard)
+  @Roles(Role.ARTIST)
+  @Patch(':id/status')
+  updateStatus(
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Body() dto: UpdateCommissionStatusDto,
+  ) {
+    const user = req.user as { id: string };
+    return this.commissionsService.updateStatus(id, dto.status, user.id);
   }
 
   @UseGuards(RolesGuard)

--- a/apps/backend/src/commissions/commissions.service.spec.ts
+++ b/apps/backend/src/commissions/commissions.service.spec.ts
@@ -172,6 +172,50 @@ describe('CommissionsService', () => {
     });
   });
 
+  describe('updateStatus', () => {
+    const userId = 'artist-uuid';
+
+    it('should update status when artist is the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'artist-uuid',
+      });
+      const updated = { id: 'uuid-1', status: 'IN_PROGRESS' };
+      mockPrisma.commission.update.mockResolvedValue(updated);
+
+      const result = await service.updateStatus(
+        'uuid-1',
+        'IN_PROGRESS',
+        userId,
+      );
+
+      expect(mockPrisma.commission.update).toHaveBeenCalledWith({
+        where: { id: 'uuid-1' },
+        data: { status: 'IN_PROGRESS' },
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('should throw ForbiddenException when artist is not the owner', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue({
+        id: 'uuid-1',
+        artistId: 'other-artist',
+      });
+
+      await expect(
+        service.updateStatus('uuid-1', 'IN_PROGRESS', userId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if commission does not exist', async () => {
+      mockPrisma.commission.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateStatus('nonexistent', 'IN_PROGRESS', userId),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('remove', () => {
     const userId = 'artist-uuid';
 

--- a/apps/backend/src/commissions/commissions.service.ts
+++ b/apps/backend/src/commissions/commissions.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
+import { Status } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -58,6 +59,17 @@ export class CommissionsService {
       throw new ForbiddenException('You can only update your own commissions');
     }
     return this.prisma.commission.update({ where: { id }, data: dto });
+  }
+
+  async updateStatus(id: string, status: Status, userId: string) {
+    const commission = await this.findById(id);
+    if (commission.artistId !== userId) {
+      throw new ForbiddenException('You can only update your own commissions');
+    }
+    return this.prisma.commission.update({
+      where: { id },
+      data: { status },
+    });
   }
 
   async remove(id: string, userId: string) {

--- a/apps/backend/src/commissions/dto/update-commission-status.dto.ts
+++ b/apps/backend/src/commissions/dto/update-commission-status.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+
+export enum CommissionStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  WAITING_PAYMENT = 'WAITING_PAYMENT',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}
+
+export class UpdateCommissionStatusDto {
+  @IsEnum(CommissionStatus, { message: 'Status inválido' })
+  @IsNotEmpty({ message: 'O status é obrigatório' })
+  status: CommissionStatus;
+}

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -1,21 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { Request } from 'express';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
 
 describe('UsersController', () => {
   let controller: UsersController;
 
   const mockService = {
-    create: jest.fn(),
     findAll: jest.fn(),
     findOne: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
   };
 
-  const mockGuard = { canActivate: jest.fn(() => true) };
+  const mockJwtGuard = { canActivate: jest.fn(() => true) };
+  const mockRolesGuard = { canActivate: jest.fn(() => true) };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,7 +25,9 @@ describe('UsersController', () => {
       providers: [{ provide: UsersService, useValue: mockService }],
     })
       .overrideGuard(JwtAuthGuard)
-      .useValue(mockGuard)
+      .useValue(mockJwtGuard)
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
       .compile();
 
     controller = module.get<UsersController>(UsersController);
@@ -36,7 +40,7 @@ describe('UsersController', () => {
   });
 
   describe('findAll', () => {
-    it('should return all users', async () => {
+    it('should call service.findAll', async () => {
       const expected = [{ id: 'uuid-1', name: 'John' }];
       mockService.findAll.mockResolvedValue(expected);
 
@@ -46,12 +50,39 @@ describe('UsersController', () => {
   });
 
   describe('findOne', () => {
-    it('should return a user by id', async () => {
+    it('should return a user for ARTIST', async () => {
+      const user = { id: 'artist-uuid', role: 'ARTIST' };
+      const req = { user };
       const expected = { id: 'uuid-1', name: 'John' };
       mockService.findOne.mockResolvedValue(expected);
 
-      const result = await controller.findOne('uuid-1');
+      const result = await controller.findOne(
+        req as unknown as Request,
+        'uuid-1',
+      );
       expect(result).toEqual(expected);
+    });
+
+    it('should return the user when CLIENT requests own id', async () => {
+      const user = { id: 'my-uuid', role: 'CLIENT' };
+      const req = { user };
+      const expected = { id: 'my-uuid', name: 'John' };
+      mockService.findOne.mockResolvedValue(expected);
+
+      const result = await controller.findOne(
+        req as unknown as Request,
+        'my-uuid',
+      );
+      expect(result).toEqual(expected);
+    });
+
+    it('should throw ForbiddenException when CLIENT requests other user', () => {
+      const user = { id: 'my-uuid', role: 'CLIENT' };
+      const req = { user };
+
+      expect(() =>
+        controller.findOne(req as unknown as Request, 'other-uuid'),
+      ).toThrow(ForbiddenException);
     });
   });
 

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -7,11 +7,15 @@ import {
   Param,
   Req,
   UseGuards,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from './dto/create-user.dto';
 import type { Request } from 'express';
 
 @ApiTags('Users')
@@ -26,7 +30,8 @@ export class UsersController {
     return req.user;
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ARTIST)
   @Get()
   findAll() {
     return this.usersService.findAll();
@@ -34,7 +39,11 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Get(':id')
-  findOne(@Param('id') id: string) {
+  findOne(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as { id: string; role: Role };
+    if (user.role !== Role.ARTIST && user.id !== id) {
+      throw new ForbiddenException('You can only access your own data');
+    }
     return this.usersService.findOne(id);
   }
 

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -130,7 +130,7 @@ Blindagem de entrada da API.
 Checklist:
 
 * [x] CreateUserDTO
-* [ ] LoginDTO (pendente — aguarda ID8)
+* [x] LoginDTO
 * [x] CreateCommissionDTO
 * [x] UpdateCommissionDTO
 * [x] ValidationPipe global ativo
@@ -174,11 +174,11 @@ Controle de acesso seguro.
 
 Checklist:
 
-* [ ] Endpoint register
-* [ ] Endpoint login
-* [ ] JWT funcionando
-* [ ] RoleGuard implementado
-* [ ] Ownership validation implementada
+* [x] Endpoint register
+* [x] Endpoint login
+* [x] JWT funcionando
+* [x] RoleGuard implementado
+* [x] Ownership validation implementada
 
 Evidência:
 
@@ -222,7 +222,7 @@ Checklist:
 * [x] Testes criados antes da lógica
 * [x] Testes Services
 * [x] Testes Controllers
-* [ ] Testes Auth (pendente — aguarda ID8)
+* [x] Testes Auth
 
 Evidência:
 
@@ -243,7 +243,7 @@ Checklist:
 * [x] `npm run test` executa corretamente
 * [x] Cobertura de sucesso
 * [x] Cobertura de erro
-* [ ] Pipeline executa testes automaticamente (opcional nesta fase)
+* [x] Pipeline executa testes automaticamente
 
 Evidência:
 
@@ -263,11 +263,11 @@ Documentação interativa da API.
 
 Checklist:
 
-* [ ] Swagger configurado
-* [ ] Endpoints auth documentados
-* [ ] Endpoints users documentados
-* [ ] Endpoints commissions documentados
-* [ ] Endpoints deliveries documentados
+* [x] Swagger configurado
+* [x] Endpoints auth documentados
+* [x] Endpoints users documentados
+* [x] Endpoints commissions documentados
+* [x] Endpoints deliveries documentados
 
 Evidência:
 
@@ -329,10 +329,10 @@ Proteção de credenciais sensíveis.
 
 Checklist:
 
-* [ ] `.env` ignorado no git
-* [ ] DATABASE_URL protegida
-* [ ] JWT_SECRET protegido
-* [ ] ConfigModule configurado
+* [x] `.env` ignorado no git
+* [x] DATABASE_URL protegida
+* [x] JWT_SECRET protegido
+* [x] ConfigModule configurado
 
 Evidência:
 
@@ -350,10 +350,10 @@ Validação automática antes de merge.
 
 Checklist:
 
-* [ ] Workflow criado
-* [ ] Lint executado
-* [ ] Testes executados
-* [ ] Pipeline bloqueia erro
+* [x] Workflow criado
+* [x] Lint executado
+* [x] Testes executados
+* [x] Pipeline bloqueia erro
 
 Evidência:
 


### PR DESCRIPTION
## O que foi feito

### Gaps do backend corrigidos

**Permissões de Users (SSD)**
- `GET /users` → agora só ARTIST pode listar todos os usuários (`RolesGuard` + `@Roles(ARTIST)`)
- `GET /users/:id` → ARTIST vê qualquer usuário; CLIENT só vê a si próprio (ownership check)

**Endpoint de Status**
- `PATCH /commissions/:id/status` → endpoint dedicado para atualizar status da comissão
- DTO `UpdateCommissionStatusDto` com validação dos valores permitidos (`PENDING`, `IN_PROGRESS`, `WAITING_PAYMENT`, `COMPLETED`, `CANCELLED`)
- Mesma ownership check do `update` e `remove`

**Checklist**
- Marcados como concluídos: ID8 (JWT+Roles+Guards), ID12 (Swagger), ID15 (variáveis seguras), ID16 (CI pipeline)
- LoginDTO marcado como existente

### Resultado
- ✅ 68 testes unitários passando (11 suites)
- ✅ Lint limpo
- ✅ Build compila sem erros