### PR TITLE
feat: layout, router + protected routes — Header, AppLayout, ProtectedRoute (ID13)

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Stack
 - React 19 + TypeScript 6
-- Vite 8
-- Tailwind CSS v4
+- Vite 8 + Tailwind CSS v4
 - React Router v7
-- Vitest + Testing Library
+- axios + @tanstack/react-query
+- Vitest + Testing Library (40 testes)
 
 ## Design Tokens (Tailwind `@theme`)
 Extraídos do Stitch — protótipo "CommissionTrack Landing Page" (light mode, minimalist + soft modern).
@@ -31,21 +31,36 @@ Extraídos do Stitch — protótipo "CommissionTrack Landing Page" (light mode, 
 }
 ```
 
+## Arquitetura
+```
+src/
+├── components/
+│   ├── ui/           # Button, Input, Card, StatusBadge, Loading
+│   └── layout/       # Header, AppLayout, ProtectedRoute
+├── pages/            # 9 telas (uma pasta cada)
+├── services/         # api.ts (axios + JWT interceptor)
+├── stores/           # AuthContext (AuthProvider + useAuth)
+├── types/            # api.ts (Role, CommissionStatus, User, etc.)
+```
+
 ## Telas (ID13 — 9 telas)
-| # | Tela | Rota | Role |
-|---|---|---|---|
-| 1 | **Login** | `/login` | Público |
-| 2 | **Cadastro** | `/cadastro` | Público |
-| 3 | **Landing Page** | `/` | Público |
-| 4 | **Painel do Artista** | `/artista/painel` | Artista |
-| 5 | **Gerenciar Clientes** | `/artista/clientes` | Artista |
-| 6 | **Detalhes da Comissão (Artista)** | `/artista/comissoes/:id` | Artista |
-| 7 | **Minhas Comissões** | `/cliente/comissoes` | Cliente |
-| 8 | **Nova Comissão** | `/cliente/nova` | Cliente |
-| 9 | **Detalhes da Comissão** | `/cliente/comissoes/:id` | Cliente |
+| # | Tela | Rota | Role | Status |
+|---|---|---|---|---|
+| 1 | **Login** | `/login` | Público | [ ] |
+| 2 | **Cadastro** | `/cadastro` | Público | [ ] |
+| 3 | **Landing Page** | `/` | Público | [ ] |
+| 4 | **Painel do Artista** | `/artista/painel` | Artista | [ ] |
+| 5 | **Gerenciar Clientes** | `/artista/clientes` | Artista | [ ] |
+| 6 | **Detalhes da Comissão (Artista)** | `/artista/comissoes/:id` | Artista | [ ] |
+| 7 | **Minhas Comissões** | `/cliente/comissoes` | Cliente | [ ] |
+| 8 | **Nova Comissão** | `/cliente/nova` | Cliente | [ ] |
+| 9 | **Detalhes da Comissão** | `/cliente/comissoes/:id` | Cliente | [ ] |
 
 ## Regras
 - TDD: test first, code second
 - Prefixo da API: `/api/v1`
-- npm run dev:web — inicia frontend
+- Rotas protegidas via ProtectedRoute + RolesGuard
+- npm run dev:web — inicia frontend (localhost:5173)
 - npm run test -w apps/frontend — roda testes
+- npm run build -w apps/frontend — valida TS + build
+- npm run lint -w apps/frontend — lint

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,10 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>CommissionTrack</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,45 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { AuthProvider } from './stores/AuthContext'
+import { AppLayout } from './components/layout/AppLayout'
+import { ProtectedRoute } from './components/layout/ProtectedRoute'
+import { Role } from './types/api'
+
+import { Landing } from './pages/Landing/Landing'
+import { Login } from './pages/Login/Login'
+import { Cadastro } from './pages/Cadastro/Cadastro'
+import { ArtistaPainel } from './pages/ArtistaPainel/ArtistaPainel'
+import { ArtistaClientes } from './pages/ArtistaClientes/ArtistaClientes'
+import { ArtistaComissaoDetalhes } from './pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes'
+import { ClienteComissoes } from './pages/ClienteComissoes/ClienteComissoes'
+import { ClienteNovaComissao } from './pages/ClienteNovaComissao/ClienteNovaComissao'
+import { ClienteComissaoDetalhes } from './pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes'
+
 function App() {
-  return <div />
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Landing />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/cadastro" element={<Cadastro />} />
+
+            <Route element={<ProtectedRoute allowedRoles={[Role.ARTIST]} />}>
+              <Route path="/artista/painel" element={<ArtistaPainel />} />
+              <Route path="/artista/clientes" element={<ArtistaClientes />} />
+              <Route path="/artista/comissoes/:id" element={<ArtistaComissaoDetalhes />} />
+            </Route>
+
+            <Route element={<ProtectedRoute allowedRoles={[Role.CLIENT]} />}>
+              <Route path="/cliente/comissoes" element={<ClienteComissoes />} />
+              <Route path="/cliente/nova" element={<ClienteNovaComissao />} />
+              <Route path="/cliente/comissoes/:id" element={<ClienteComissaoDetalhes />} />
+            </Route>
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/apps/frontend/src/components/layout/AppLayout.test.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { AppLayout } from './AppLayout'
+import { AuthProvider } from '../../stores/AuthContext'
+
+describe('AppLayout', () => {
+  it('renders header', () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Routes>
+            <Route element={<AppLayout />}>
+              <Route path="/" element={<div>Conteúdo</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('CommissionTrack')).toBeInTheDocument()
+  })
+
+  it('renders children via Outlet', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthProvider>
+          <Routes>
+            <Route element={<AppLayout />}>
+              <Route path="/" element={<div>Conteúdo da Página</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Conteúdo da Página')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom'
+import { Header } from './Header'
+
+export function AppLayout() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-8 sm:px-6 lg:px-8">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/layout/Header.test.tsx
+++ b/apps/frontend/src/components/layout/Header.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Header } from './Header'
+import { AuthProvider } from '../../stores/AuthContext'
+import { Role } from '../../types/api'
+
+function renderWithRouter() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <Header />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('Header', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders logo', () => {
+    renderWithRouter()
+    expect(screen.getByText('CommissionTrack')).toBeInTheDocument()
+  })
+
+  it('shows login and cadastro links when not authenticated', () => {
+    renderWithRouter()
+    expect(screen.getByText('Entrar')).toBeInTheDocument()
+    expect(screen.getByText('Cadastrar')).toBeInTheDocument()
+  })
+
+  it('shows artist nav links when authenticated as ARTIST', () => {
+    localStorage.setItem('token', 'fake-token')
+    localStorage.setItem('user', JSON.stringify({ id: '1', name: 'Artista', email: 'a@a.com', role: Role.ARTIST, createdAt: '2024-01-01' }))
+
+    renderWithRouter()
+    expect(screen.getByText('Painel')).toBeInTheDocument()
+    expect(screen.getByText('Clientes')).toBeInTheDocument()
+    expect(screen.getByText('Sair')).toBeInTheDocument()
+    expect(screen.getByText('Artista')).toBeInTheDocument()
+    expect(screen.queryByText('Entrar')).not.toBeInTheDocument()
+  })
+
+  it('shows client nav links when authenticated as CLIENT', () => {
+    localStorage.setItem('token', 'fake-token')
+    localStorage.setItem('user', JSON.stringify({ id: '2', name: 'Cliente', email: 'c@c.com', role: Role.CLIENT, createdAt: '2024-01-01' }))
+
+    renderWithRouter()
+    expect(screen.getByText('Minhas Comissões')).toBeInTheDocument()
+    expect(screen.getByText('Sair')).toBeInTheDocument()
+    expect(screen.getByText('Cliente')).toBeInTheDocument()
+    expect(screen.queryByText('Entrar')).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,80 @@
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../../stores/AuthContext'
+import { Role } from '../../types/api'
+
+export function Header() {
+  const { isAuthenticated, user, logout } = useAuth()
+  const navigate = useNavigate()
+
+  function handleLogout() {
+    logout()
+    navigate('/')
+  }
+
+  return (
+    <header className="bg-surface border-b border-[#e5e4e7]">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <Link to="/" className="font-display text-xl font-bold text-primary no-underline">
+          CommissionTrack
+        </Link>
+
+        <nav className="flex items-center gap-4">
+          {!isAuthenticated && (
+            <>
+              <Link
+                to="/login"
+                className="text-sm font-medium text-tertiary no-underline hover:text-on-surface transition-colors"
+              >
+                Entrar
+              </Link>
+              <Link
+                to="/cadastro"
+                className="inline-flex items-center justify-center gap-2 rounded-sm bg-primary px-3 py-1.5 text-sm font-semibold text-white no-underline transition-colors hover:brightness-90"
+              >
+                Cadastrar
+              </Link>
+            </>
+          )}
+
+          {isAuthenticated && user && (
+            <>
+              {user.role === Role.ARTIST && (
+                <>
+                  <Link
+                    to="/artista/painel"
+                    className="text-sm font-medium text-tertiary no-underline hover:text-on-surface transition-colors"
+                  >
+                    Painel
+                  </Link>
+                  <Link
+                    to="/artista/clientes"
+                    className="text-sm font-medium text-tertiary no-underline hover:text-on-surface transition-colors"
+                  >
+                    Clientes
+                  </Link>
+                </>
+              )}
+              {user.role === Role.CLIENT && (
+                <Link
+                  to="/cliente/comissoes"
+                  className="text-sm font-medium text-tertiary no-underline hover:text-on-surface transition-colors"
+                >
+                  Minhas Comissões
+                </Link>
+              )}
+
+              <span className="text-sm text-tertiary">{user.name}</span>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="cursor-pointer text-sm font-medium text-tertiary no-underline hover:text-primary transition-colors"
+              >
+                Sair
+              </button>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/apps/frontend/src/components/layout/ProtectedRoute.test.tsx
+++ b/apps/frontend/src/components/layout/ProtectedRoute.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ProtectedRoute } from './ProtectedRoute'
+import { AuthProvider } from '../../stores/AuthContext'
+import { Role } from '../../types/api'
+
+function renderWithProviders(path: string, ui: React.ReactElement) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/protegida" element={ui} />
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/artista/painel" element={<div>Painel do Artista</div>} />
+          <Route path="/cliente/comissoes" element={<div>Comissões Cliente</div>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('redirects to /login when not authenticated', async () => {
+    renderWithProviders(
+      '/protegida',
+      <ProtectedRoute>
+        <div>Conteúdo Protegido</div>
+      </ProtectedRoute>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Login Page')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Conteúdo Protegido')).not.toBeInTheDocument()
+  })
+
+  it('redirects ARTIST to /artista/painel when trying to access client route', async () => {
+    localStorage.setItem('token', 'fake-token')
+    localStorage.setItem('user', JSON.stringify({ id: '1', name: 'Test', email: 'test@test.com', role: Role.ARTIST, createdAt: '2024-01-01' }))
+
+    renderWithProviders(
+      '/protegida',
+      <ProtectedRoute allowedRoles={[Role.CLIENT]}>
+        <div>Conteúdo Cliente</div>
+      </ProtectedRoute>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Painel do Artista')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Conteúdo Cliente')).not.toBeInTheDocument()
+  })
+
+  it('redirects CLIENT to /cliente/comissoes when trying to access artist route', async () => {
+    localStorage.setItem('token', 'fake-token')
+    localStorage.setItem('user', JSON.stringify({ id: '2', name: 'Client', email: 'client@test.com', role: Role.CLIENT, createdAt: '2024-01-01' }))
+
+    renderWithProviders(
+      '/protegida',
+      <ProtectedRoute allowedRoles={[Role.ARTIST]}>
+        <div>Conteúdo Artista</div>
+      </ProtectedRoute>,
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Comissões Cliente')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Conteúdo Artista')).not.toBeInTheDocument()
+  })
+
+  it('renders children when authenticated with matching role', () => {
+    localStorage.setItem('token', 'fake-token')
+    localStorage.setItem('user', JSON.stringify({ id: '1', name: 'Test', email: 'test@test.com', role: Role.ARTIST, createdAt: '2024-01-01' }))
+
+    renderWithProviders(
+      '/protegida',
+      <ProtectedRoute allowedRoles={[Role.ARTIST]}>
+        <div>Conteúdo Protegido</div>
+      </ProtectedRoute>,
+    )
+    expect(screen.getByText('Conteúdo Protegido')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/layout/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../../stores/AuthContext'
+import { Role } from '../../types/api'
+
+interface ProtectedRouteProps {
+  children?: React.ReactNode
+  allowedRoles?: Role[]
+}
+
+function getDefaultRoute(role: Role): string {
+  if (role === Role.ARTIST) return '/artista/painel'
+  return '/cliente/comissoes'
+}
+
+export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
+  const { isAuthenticated, user } = useAuth()
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  if (allowedRoles && user && !allowedRoles.includes(user.role)) {
+    return <Navigate to={getDefaultRoute(user.role)} replace />
+  }
+
+  return children ? <>{children}</> : <Outlet />
+}

--- a/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
+++ b/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
@@ -1,0 +1,3 @@
+export function ArtistaClientes() {
+  return <div>Gerenciar Clientes</div>
+}

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
@@ -1,0 +1,3 @@
+export function ArtistaComissaoDetalhes() {
+  return <div>Detalhes da Comissão (Artista)</div>
+}

--- a/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
+++ b/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
@@ -1,0 +1,3 @@
+export function ArtistaPainel() {
+  return <div>Painel do Artista</div>
+}

--- a/apps/frontend/src/pages/Cadastro/Cadastro.tsx
+++ b/apps/frontend/src/pages/Cadastro/Cadastro.tsx
@@ -1,0 +1,3 @@
+export function Cadastro() {
+  return <div>Cadastro</div>
+}

--- a/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
@@ -1,0 +1,3 @@
+export function ClienteComissaoDetalhes() {
+  return <div>Detalhes da Comissão</div>
+}

--- a/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.tsx
+++ b/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.tsx
@@ -1,0 +1,3 @@
+export function ClienteComissoes() {
+  return <div>Minhas Comissões</div>
+}

--- a/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.tsx
+++ b/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.tsx
@@ -1,0 +1,3 @@
+export function ClienteNovaComissao() {
+  return <div>Nova Comissão</div>
+}

--- a/apps/frontend/src/pages/Landing/Landing.tsx
+++ b/apps/frontend/src/pages/Landing/Landing.tsx
@@ -1,0 +1,8 @@
+export function Landing() {
+  return (
+    <div>
+      <h1 className="font-display text-4xl font-bold text-on-surface">CommissionTrack</h1>
+      <p className="text-tertiary">Conectando artistas e clientes.</p>
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Login/Login.tsx
+++ b/apps/frontend/src/pages/Login/Login.tsx
@@ -1,0 +1,3 @@
+export function Login() {
+  return <div>Login</div>
+}


### PR DESCRIPTION
- Header: role-based nav (artist/client/public), brand logo, logout\n- AppLayout: Header + main content area with Outlet\n- ProtectedRoute: redirect /login when unauthenticated, role mismatch → default dashboard\n- Router config with all 9 routes and role-based guards\n- Placeholder pages for all screens\n- index.html: Google Fonts (Inter + Plus Jakarta Sans)\n- 40 tests total (10 new: ProtectedRoute 4, Header 4, AppLayout 2)\n\n**40/40 tests ✅ | Build ✅ | Lint ✅**