### PR TITLE
feat: landing page, 404, unauthorized pages (ID13)

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { Role } from './types/api'
 import { Landing } from './pages/Landing/Landing'
 import { Login } from './pages/Login/Login'
 import { Cadastro } from './pages/Cadastro/Cadastro'
+import { NotFound } from './pages/NotFound/NotFound'
+import { Unauthorized } from './pages/Unauthorized/Unauthorized'
 import { ArtistaPainel } from './pages/ArtistaPainel/ArtistaPainel'
 import { ArtistaClientes } from './pages/ArtistaClientes/ArtistaClientes'
 import { ArtistaComissaoDetalhes } from './pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes'
@@ -23,6 +25,7 @@ function App() {
             <Route path="/" element={<Landing />} />
             <Route path="/login" element={<Login />} />
             <Route path="/cadastro" element={<Cadastro />} />
+            <Route path="/unauthorized" element={<Unauthorized />} />
 
             <Route element={<ProtectedRoute allowedRoles={[Role.ARTIST]} />}>
               <Route path="/artista/painel" element={<ArtistaPainel />} />
@@ -35,6 +38,8 @@ function App() {
               <Route path="/cliente/nova" element={<ClienteNovaComissao />} />
               <Route path="/cliente/comissoes/:id" element={<ClienteComissaoDetalhes />} />
             </Route>
+
+            <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>
       </AuthProvider>

--- a/apps/frontend/src/components/layout/ProtectedRoute.test.tsx
+++ b/apps/frontend/src/components/layout/ProtectedRoute.test.tsx
@@ -12,6 +12,7 @@ function renderWithProviders(path: string, ui: React.ReactElement) {
         <Routes>
           <Route path="/protegida" element={ui} />
           <Route path="/login" element={<div>Login Page</div>} />
+          <Route path="/unauthorized" element={<div>Unauthorized Page</div>} />
           <Route path="/artista/painel" element={<div>Painel do Artista</div>} />
           <Route path="/cliente/comissoes" element={<div>Comissões Cliente</div>} />
         </Routes>
@@ -38,7 +39,7 @@ describe('ProtectedRoute', () => {
     expect(screen.queryByText('Conteúdo Protegido')).not.toBeInTheDocument()
   })
 
-  it('redirects ARTIST to /artista/painel when trying to access client route', async () => {
+  it('redirects to /unauthorized when role does not match', async () => {
     localStorage.setItem('token', 'fake-token')
     localStorage.setItem('user', JSON.stringify({ id: '1', name: 'Test', email: 'test@test.com', role: Role.ARTIST, createdAt: '2024-01-01' }))
 
@@ -49,25 +50,9 @@ describe('ProtectedRoute', () => {
       </ProtectedRoute>,
     )
     await waitFor(() => {
-      expect(screen.getByText('Painel do Artista')).toBeInTheDocument()
+      expect(screen.getByText('Unauthorized Page')).toBeInTheDocument()
     })
     expect(screen.queryByText('Conteúdo Cliente')).not.toBeInTheDocument()
-  })
-
-  it('redirects CLIENT to /cliente/comissoes when trying to access artist route', async () => {
-    localStorage.setItem('token', 'fake-token')
-    localStorage.setItem('user', JSON.stringify({ id: '2', name: 'Client', email: 'client@test.com', role: Role.CLIENT, createdAt: '2024-01-01' }))
-
-    renderWithProviders(
-      '/protegida',
-      <ProtectedRoute allowedRoles={[Role.ARTIST]}>
-        <div>Conteúdo Artista</div>
-      </ProtectedRoute>,
-    )
-    await waitFor(() => {
-      expect(screen.getByText('Comissões Cliente')).toBeInTheDocument()
-    })
-    expect(screen.queryByText('Conteúdo Artista')).not.toBeInTheDocument()
   })
 
   it('renders children when authenticated with matching role', () => {

--- a/apps/frontend/src/components/layout/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/layout/ProtectedRoute.tsx
@@ -1,15 +1,10 @@
 import { Navigate, Outlet } from 'react-router-dom'
 import { useAuth } from '../../stores/AuthContext'
-import { Role } from '../../types/api'
+import type { Role } from '../../types/api'
 
 interface ProtectedRouteProps {
   children?: React.ReactNode
   allowedRoles?: Role[]
-}
-
-function getDefaultRoute(role: Role): string {
-  if (role === Role.ARTIST) return '/artista/painel'
-  return '/cliente/comissoes'
 }
 
 export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
@@ -20,7 +15,7 @@ export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) 
   }
 
   if (allowedRoles && user && !allowedRoles.includes(user.role)) {
-    return <Navigate to={getDefaultRoute(user.role)} replace />
+    return <Navigate to="/unauthorized" replace />
   }
 
   return children ? <>{children}</> : <Outlet />

--- a/apps/frontend/src/pages/Landing/Landing.test.tsx
+++ b/apps/frontend/src/pages/Landing/Landing.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import { Landing } from './Landing'
+
+vi.mock('../../stores/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    user: null,
+  }),
+}))
+
+function renderLanding() {
+  return render(
+    <MemoryRouter>
+      <Landing />
+    </MemoryRouter>,
+  )
+}
+
+describe('Landing', () => {
+  it('renders hero title', () => {
+    renderLanding()
+    expect(screen.getByText('CommissionTrack')).toBeInTheDocument()
+  })
+
+  it('renders hero subtitle', () => {
+    renderLanding()
+    expect(screen.getByText(/conectando artistas e clientes/i)).toBeInTheDocument()
+  })
+
+  it('has call-to-action buttons for unauthenticated users', () => {
+    renderLanding()
+    const cadastrar = screen.getByRole('link', { name: /começar agora/i })
+    expect(cadastrar).toBeInTheDocument()
+    expect(cadastrar).toHaveAttribute('href', '/cadastro')
+
+    const entrar = screen.getByRole('link', { name: /entrar/i })
+    expect(entrar).toBeInTheDocument()
+    expect(entrar).toHaveAttribute('href', '/login')
+  })
+
+  it('renders feature cards', () => {
+    renderLanding()
+    expect(screen.getByText('Gerencie Comissões')).toBeInTheDocument()
+    expect(screen.getByText('Controle de Prazos')).toBeInTheDocument()
+    expect(screen.getByText('Entregas Organizadas')).toBeInTheDocument()
+  })
+
+  it('renders footer with current year', () => {
+    renderLanding()
+    const year = new Date().getFullYear()
+    expect(screen.getByText(new RegExp(year.toString()))).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/pages/Landing/Landing.tsx
+++ b/apps/frontend/src/pages/Landing/Landing.tsx
@@ -1,8 +1,142 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../stores/AuthContext'
+import { Role } from '../../types/api'
+
+function getDashboardLink(role: Role): string {
+  if (role === Role.ARTIST) return '/artista/painel'
+  return '/cliente/comissoes'
+}
+
 export function Landing() {
+  const { isAuthenticated, user } = useAuth()
+
   return (
     <div>
-      <h1 className="font-display text-4xl font-bold text-on-surface">CommissionTrack</h1>
-      <p className="text-tertiary">Conectando artistas e clientes.</p>
+      <section className="mx-auto mt-16 max-w-3xl px-4 text-center sm:mt-24">
+        <h1 className="font-display text-4xl font-bold text-on-surface sm:text-5xl">
+          CommissionTrack
+        </h1>
+        <p className="mt-4 text-lg text-tertiary">
+          Conectando artistas e clientes.
+        </p>
+        <p className="mt-2 text-sm text-tertiary">
+          Gerencie comissões, acompanhe prazos e organize entregas em um só lugar.
+        </p>
+
+        <div className="mt-8 flex items-center justify-center gap-4">
+          {isAuthenticated && user ? (
+            <Link
+              to={getDashboardLink(user.role)}
+              className="inline-flex items-center justify-center gap-2 rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:brightness-90"
+            >
+              Ir para o painel
+            </Link>
+          ) : (
+            <>
+              <Link
+                to="/cadastro"
+                className="inline-flex items-center justify-center gap-2 rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:brightness-90"
+              >
+                Começar agora
+              </Link>
+              <Link
+                to="/login"
+                className="inline-flex items-center justify-center gap-2 rounded-sm border border-[#e5e4e7] bg-surface px-6 py-2.5 text-sm font-semibold text-on-surface no-underline transition-colors hover:bg-[#f9f9f9]"
+              >
+                Entrar
+              </Link>
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className="mx-auto mt-24 max-w-5xl px-4 sm:mt-32">
+        <div className="grid gap-6 sm:grid-cols-3">
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#e60023"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+                <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+              </svg>
+            </div>
+            <h3 className="font-display text-base font-semibold text-on-surface">
+              Gerencie Comissões
+            </h3>
+            <p className="mt-1 text-sm text-tertiary">
+              Crie e acompanhe pedidos de forma organizada.
+            </p>
+          </div>
+
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#e60023"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </div>
+            <h3 className="font-display text-base font-semibold text-on-surface">
+              Controle de Prazos
+            </h3>
+            <p className="mt-1 text-sm text-tertiary">
+              Nunca perca um prazo de entrega novamente.
+            </p>
+          </div>
+
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card">
+            <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#e60023"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <polyline points="14 2 14 8 20 8" />
+                <line x1="16" y1="13" x2="8" y2="13" />
+                <line x1="16" y1="17" x2="8" y2="17" />
+                <polyline points="10 9 9 9 8 9" />
+              </svg>
+            </div>
+            <h3 className="font-display text-base font-semibold text-on-surface">
+              Entregas Organizadas
+            </h3>
+            <p className="mt-1 text-sm text-tertiary">
+              Mantenha um histórico completo de entregas.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <footer className="mx-auto mt-24 max-w-7xl border-t border-[#e5e4e7] px-4 py-8 text-center sm:mt-32">
+        <p className="text-sm text-tertiary">
+          &copy; {new Date().getFullYear()} CommissionTrack. Todos os direitos reservados.
+        </p>
+      </footer>
     </div>
   )
 }

--- a/apps/frontend/src/pages/NotFound/NotFound.test.tsx
+++ b/apps/frontend/src/pages/NotFound/NotFound.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { NotFound } from './NotFound'
+
+function renderNotFound() {
+  return render(
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>,
+  )
+}
+
+describe('NotFound', () => {
+  it('renders 404 message', () => {
+    renderNotFound()
+    expect(screen.getByText('404')).toBeInTheDocument()
+  })
+
+  it('renders page not found text', () => {
+    renderNotFound()
+    expect(screen.getByText(/página não encontrada/i)).toBeInTheDocument()
+  })
+
+  it('has link back to home', () => {
+    renderNotFound()
+    const link = screen.getByRole('link', { name: /voltar ao início/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/apps/frontend/src/pages/NotFound/NotFound.tsx
+++ b/apps/frontend/src/pages/NotFound/NotFound.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom'
+
+export function NotFound() {
+  return (
+    <div className="mx-auto mt-24 max-w-md px-4 text-center">
+      <h1 className="font-display text-7xl font-bold text-primary">404</h1>
+      <p className="mt-4 text-lg text-tertiary">
+        Página não encontrada
+      </p>
+      <p className="mt-2 text-sm text-tertiary">
+        A página que você procura não existe ou foi removida.
+      </p>
+      <Link
+        to="/"
+        className="mt-8 inline-block rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:brightness-90"
+      >
+        Voltar ao início
+      </Link>
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Unauthorized/Unauthorized.test.tsx
+++ b/apps/frontend/src/pages/Unauthorized/Unauthorized.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { Unauthorized } from './Unauthorized'
+
+function renderUnauthorized() {
+  return render(
+    <MemoryRouter>
+      <Unauthorized />
+    </MemoryRouter>,
+  )
+}
+
+describe('Unauthorized', () => {
+  it('renders access denied message', () => {
+    renderUnauthorized()
+    expect(screen.getByText(/acesso negado/i)).toBeInTheDocument()
+  })
+
+  it('renders permission message', () => {
+    renderUnauthorized()
+    expect(screen.getByText(/permissão/i)).toBeInTheDocument()
+  })
+
+  it('renders guidance text', () => {
+    renderUnauthorized()
+    expect(screen.getByText(/entre em contato/i)).toBeInTheDocument()
+  })
+
+  it('has link back to home', () => {
+    renderUnauthorized()
+    const link = screen.getByRole('link', { name: /voltar ao início/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/apps/frontend/src/pages/Unauthorized/Unauthorized.tsx
+++ b/apps/frontend/src/pages/Unauthorized/Unauthorized.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom'
+
+export function Unauthorized() {
+  return (
+    <div className="mx-auto mt-24 max-w-md px-4 text-center">
+      <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#e60023"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      </div>
+      <h1 className="font-display text-2xl font-bold text-on-surface">Acesso negado</h1>
+      <p className="mt-2 text-tertiary">
+        Você não tem permissão para acessar esta página.
+      </p>
+      <p className="mt-1 text-sm text-tertiary">
+        Entre em contato com o administrador se precisar de acesso.
+      </p>
+      <Link
+        to="/"
+        className="mt-8 inline-block rounded-sm bg-primary px-6 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:brightness-90"
+      >
+        Voltar ao início
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## O que foi feito

### Novas páginas públicas
1. **Landing Page** — hero section com branding, 3 feature cards (comissões, prazos, entregas), CTA buttons condicionais (autenticado → painel, não autenticado → cadastro/login), footer com ano dinâmico
2. **NotFound (404)** — rota `*` catch-all com mensagem e link "Voltar ao início"
3. **Unauthorized (`/unauthorized`)** — página de acesso negado com ícone de cadeado

### Ajustes
- **ProtectedRoute** — agora redireciona para `/unauthorized` em vez do dashboard quando a role não corresponde
- **App.tsx** — novas rotas adicionadas

### TDD
- Testes escritos antes da implementação (3 novos suites, 12 novos testes)
- Landing: hero, CTA buttons, feature cards, footer
- NotFound: 404 message, link home
- Unauthorized: access denied, guidance text, link home

### Testes
- Frontend: 69 testes (14 suites)
- Backend: 72 testes (10 suites)
- Total: 141 testes passando