### PR TITLE
feat: artist dashboard — summary cards, commission list, status update (ID13)

### DIFF
--- a/apps/backend/src/commissions/commissions.service.spec.ts
+++ b/apps/backend/src/commissions/commissions.service.spec.ts
@@ -97,6 +97,10 @@ describe('CommissionsService', () => {
   });
 
   describe('findAll', () => {
+    const include = {
+      client: { select: { id: true, name: true, email: true } },
+    };
+
     it('should return all commissions for ARTIST', async () => {
       const expected = [{ id: 'uuid-1', title: 'Portrait' }];
       mockPrisma.commission.findMany.mockResolvedValue(expected);
@@ -105,6 +109,7 @@ describe('CommissionsService', () => {
 
       expect(mockPrisma.commission.findMany).toHaveBeenCalledWith({
         where: { artistId: 'artist-uuid' },
+        include,
       });
       expect(result).toEqual(expected);
     });
@@ -119,6 +124,7 @@ describe('CommissionsService', () => {
 
       expect(mockPrisma.commission.findMany).toHaveBeenCalledWith({
         where: { clientId: 'client-uuid' },
+        include,
       });
       expect(result).toEqual(expected);
     });

--- a/apps/backend/src/commissions/commissions.service.ts
+++ b/apps/backend/src/commissions/commissions.service.ts
@@ -37,13 +37,18 @@ export class CommissionsService {
   }
 
   async findAll(userId: string, role: string) {
+    const include = {
+      client: { select: { id: true, name: true, email: true } },
+    };
     if (role === 'CLIENT') {
       return this.prisma.commission.findMany({
         where: { clientId: userId },
+        include,
       });
     }
     return this.prisma.commission.findMany({
       where: { artistId: userId },
+      include,
     });
   }
 
@@ -97,6 +102,9 @@ export class CommissionsService {
   private async findById(id: string) {
     const commission = await this.prisma.commission.findUnique({
       where: { id },
+      include: {
+        client: { select: { id: true, name: true, email: true } },
+      },
     });
     if (!commission) throw new NotFoundException('Commission not found');
     return commission;

--- a/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.test.tsx
+++ b/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ArtistaPainel } from './ArtistaPainel'
+import { CommissionStatus } from '../../types/api'
+import type { Commission, User } from '../../types/api'
+
+const client: User = {
+  id: 'client-1',
+  name: 'Maria',
+  email: 'maria@test.com',
+  role: 'CLIENT',
+  createdAt: '2024-01-01',
+}
+
+const commissions: Commission[] = [
+  {
+    id: '1',
+    title: 'Retrato Digital',
+    description: 'Descrição',
+    price: 150,
+    status: CommissionStatus.PENDING,
+    deadline: null,
+    clientId: 'client-1',
+    artistId: 'artist-1',
+    client,
+  },
+  {
+    id: '2',
+    title: 'Ilustração',
+    description: 'Descrição',
+    price: 200,
+    status: CommissionStatus.IN_PROGRESS,
+    deadline: '2024-06-01',
+    clientId: 'client-1',
+    artistId: 'artist-1',
+    client,
+  },
+]
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+})
+
+function renderPainel() {
+  return render(
+    <MemoryRouter>
+      <ArtistaPainel />
+    </MemoryRouter>,
+  )
+}
+
+describe('ArtistaPainel', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(() => new Promise(() => {}))
+
+    renderPainel()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders list of commissions', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, commissions)
+
+    renderPainel()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Ilustração')).toBeInTheDocument()
+    expect(screen.getAllByText(/Maria/)).toHaveLength(2)
+    expect(screen.getAllByText('Pendente').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Em andamento').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows summary cards', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, commissions)
+
+    renderPainel()
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no commissions', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, [])
+
+    renderPainel()
+
+    await waitFor(() => {
+      expect(screen.getByText(/nenhuma comissão/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(500)
+
+    renderPainel()
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.test.tsx
+++ b/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, afterEach } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'

--- a/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
+++ b/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
@@ -1,3 +1,170 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import api from '../../services/api'
+import { StatusBadge } from '../../components/ui/StatusBadge'
+import { CommissionStatus } from '../../types/api'
+import type { Commission } from '../../types/api'
+
+function getErrorMessage(error: unknown): string {
+  return 'Erro ao carregar comissões. Tente novamente.'
+}
+
+function getStatusCounts(commissions: Commission[]) {
+  const total = commissions.length
+  const pending = commissions.filter(c => c.status === CommissionStatus.PENDING).length
+  const inProgress = commissions.filter(c => c.status === CommissionStatus.IN_PROGRESS).length
+  const completed = commissions.filter(c => c.status === CommissionStatus.COMPLETED).length
+  return { total, pending, inProgress, completed }
+}
+
 export function ArtistaPainel() {
-  return <div>Painel do Artista</div>
+  const [commissions, setCommissions] = useState<Commission[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+
+  const fetchCommissions = useCallback(async () => {
+    setIsLoading(true)
+    setApiError('')
+    try {
+      const { data } = await api.get<Commission[]>('/commissions')
+      setCommissions(data)
+    } catch {
+      setApiError(getErrorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchCommissions()
+  }, [fetchCommissions])
+
+  async function handleStatusChange(id: string, status: CommissionStatus) {
+    setUpdatingId(id)
+    try {
+      await api.patch(`/commissions/${id}/status`, { status })
+      setCommissions(prev =>
+        prev.map(c => (c.id === id ? { ...c, status } : c)),
+      )
+    } catch {
+      setApiError('Erro ao atualizar status.')
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+        <button
+          type="button"
+          onClick={fetchCommissions}
+          className="mt-4 cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    )
+  }
+
+  const counts = getStatusCounts(commissions)
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="font-display text-2xl font-bold text-on-surface">
+          Painel do Artista
+        </h1>
+        <Link
+          to="/artista/clientes"
+          className="rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white no-underline hover:brightness-90"
+        >
+          Gerenciar Clientes
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-4 mb-8">
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Total</p>
+          <p className="font-display text-2xl font-bold text-on-surface">{counts.total}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Pendentes</p>
+          <p className="font-display text-2xl font-bold text-yellow-600">{counts.pending}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Em andamento</p>
+          <p className="font-display text-2xl font-bold text-blue-600">{counts.inProgress}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Concluídas</p>
+          <p className="font-display text-2xl font-bold text-green-600">{counts.completed}</p>
+        </div>
+      </div>
+
+      {commissions.length === 0 ? (
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-12 text-center">
+          <p className="text-tertiary">Nenhuma comissão encontrada.</p>
+          <p className="mt-1 text-sm text-tertiary">
+            Crie uma nova comissão para começar.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {commissions.map(commission => (
+            <div
+              key={commission.id}
+              className="flex items-center justify-between rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-3">
+                  <Link
+                    to={`/artista/comissoes/${commission.id}`}
+                    className="font-display text-base font-semibold text-on-surface no-underline hover:text-primary"
+                  >
+                    {commission.title}
+                  </Link>
+                  <StatusBadge status={commission.status} />
+                </div>
+                <p className="mt-1 text-sm text-tertiary">
+                  Cliente: {commission.client?.name ?? '---'} &middot; R$ {Number(commission.price).toFixed(2)}
+                  {commission.deadline && ` · Prazo: ${new Date(commission.deadline).toLocaleDateString('pt-BR')}`}
+                </p>
+              </div>
+
+              <select
+                value={commission.status}
+                onChange={(e) =>
+                  handleStatusChange(commission.id, e.target.value as CommissionStatus)
+                }
+                disabled={updatingId === commission.id}
+                className="ml-4 rounded-sm border border-[#e5e4e7] bg-surface px-2 py-1.5 text-sm text-on-surface focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+              >
+                <option value={CommissionStatus.PENDING}>Pendente</option>
+                <option value={CommissionStatus.IN_PROGRESS}>Em andamento</option>
+                <option value={CommissionStatus.WAITING_PAYMENT}>Aguardando pagamento</option>
+                <option value={CommissionStatus.COMPLETED}>Concluído</option>
+                <option value={CommissionStatus.CANCELLED}>Cancelado</option>
+              </select>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
+++ b/apps/frontend/src/pages/ArtistaPainel/ArtistaPainel.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import api from '../../services/api'
 import { StatusBadge } from '../../components/ui/StatusBadge'
 import { CommissionStatus } from '../../types/api'
 import type { Commission } from '../../types/api'
 
-function getErrorMessage(error: unknown): string {
+function getErrorMessage(): string {
   return 'Erro ao carregar comissões. Tente novamente.'
 }
 
@@ -23,22 +23,21 @@ export function ArtistaPainel() {
   const [apiError, setApiError] = useState('')
   const [updatingId, setUpdatingId] = useState<string | null>(null)
 
-  const fetchCommissions = useCallback(async () => {
-    setIsLoading(true)
-    setApiError('')
-    try {
-      const { data } = await api.get<Commission[]>('/commissions')
-      setCommissions(data)
-    } catch {
-      setApiError(getErrorMessage)
-    } finally {
-      setIsLoading(false)
-    }
+  useEffect(() => {
+    api.get<Commission[]>('/commissions')
+      .then(({ data }) => setCommissions(data))
+      .catch(() => setApiError(getErrorMessage()))
+      .finally(() => setIsLoading(false))
   }, [])
 
-  useEffect(() => {
-    fetchCommissions()
-  }, [fetchCommissions])
+  function handleRetry() {
+    setIsLoading(true)
+    setApiError('')
+    api.get<Commission[]>('/commissions')
+      .then(({ data }) => setCommissions(data))
+      .catch(() => setApiError(getErrorMessage()))
+      .finally(() => setIsLoading(false))
+  }
 
   async function handleStatusChange(id: string, status: CommissionStatus) {
     setUpdatingId(id)
@@ -73,7 +72,7 @@ export function ArtistaPainel() {
         </div>
         <button
           type="button"
-          onClick={fetchCommissions}
+          onClick={handleRetry}
           className="mt-4 cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90"
         >
           Tentar novamente


### PR DESCRIPTION
## Mudanças

### Backend
- commissions.service.ts: findAll e findById agora incluem dados do cliente via Prisma include (client: { select: { id, name, email } })
- Testes atualizados para validar o include

### Frontend
- ArtistaPainel — Painel do Artista completo com:
  - Loading state ("Carregando...")
  - 4 summary cards (Total, Pendentes, Em andamento, Concluídas)
  - Lista de comissoes com titulo, StatusBadge, nome do cliente, preco e prazo
  - Select para mudanca de status (5 opcoes)
  - Empty state quando nao ha comissoes
  - Error state com botao "Tentar novamente"
  - Link "Gerenciar Clientes" e links para detalhes de cada comissao
- 5 novos testes (loading, list, summary cards, empty, error) — todos verdes

### Testes
- Frontend: 74 passed
- Backend: 72 passed
- Total: 146 testes passando