### PR TITLE
feat: phase 1 — client flow, commission details, artist detail (ID13)

### DIFF
--- a/apps/backend/src/commissions/commissions.controller.spec.ts
+++ b/apps/backend/src/commissions/commissions.controller.spec.ts
@@ -42,8 +42,8 @@ describe('CommissionsController', () => {
   });
 
   describe('create', () => {
-    it('should call service.create with DTO and authenticated artist', async () => {
-      const user = { id: 'artist-uuid' };
+    it('should call service.create with DTO, userId and role for ARTIST', async () => {
+      const user = { id: 'artist-uuid', role: 'ARTIST' };
       const req = { user };
       const dto = {
         title: 'Portrait',
@@ -56,7 +56,11 @@ describe('CommissionsController', () => {
 
       const result = await controller.create(req as unknown as Request, dto);
 
-      expect(mockService.create).toHaveBeenCalledWith(dto, 'artist-uuid');
+      expect(mockService.create).toHaveBeenCalledWith(
+        dto,
+        'artist-uuid',
+        'ARTIST',
+      );
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/commissions/commissions.controller.ts
+++ b/apps/backend/src/commissions/commissions.controller.ts
@@ -28,11 +28,11 @@ export class CommissionsController {
   constructor(private readonly commissionsService: CommissionsService) {}
 
   @UseGuards(RolesGuard)
-  @Roles(Role.ARTIST)
+  @Roles(Role.ARTIST, Role.CLIENT)
   @Post()
   create(@Req() req: Request, @Body() dto: CreateCommissionDto) {
-    const user = req.user as { id: string };
-    return this.commissionsService.create(dto, user.id);
+    const user = req.user as { id: string; role: string };
+    return this.commissionsService.create(dto, user.id, user.role);
   }
 
   @Get()

--- a/apps/backend/src/commissions/commissions.service.spec.ts
+++ b/apps/backend/src/commissions/commissions.service.spec.ts
@@ -37,7 +37,7 @@ describe('CommissionsService', () => {
   afterEach(() => jest.clearAllMocks());
 
   describe('create', () => {
-    const dto = {
+    const artistDto = {
       title: 'Portrait',
       description: 'Digital art',
       price: 150,
@@ -45,54 +45,91 @@ describe('CommissionsService', () => {
     };
     const artistId = 'artist-uuid';
 
-    it('should create a commission', async () => {
+    it('should create a commission as ARTIST', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         id: 'client-uuid',
         role: 'CLIENT',
       });
-      mockPrisma.user.findUnique.mockResolvedValueOnce({
-        id: 'artist-uuid',
-        role: 'ARTIST',
-      });
-      const expected = { id: 'uuid-1', ...dto, artistId, status: 'PENDING' };
+      const expected = {
+        id: 'uuid-1',
+        ...artistDto,
+        artistId,
+        status: 'PENDING',
+      };
       mockPrisma.commission.create.mockResolvedValue(expected);
 
-      const result = await service.create(dto, artistId);
+      const result = await service.create(artistDto, artistId, 'ARTIST');
       expect(result).toEqual(expected);
     });
 
-    it('should throw BadRequestException when client role is not CLIENT', async () => {
+    it('should throw BadRequestException when client role is not CLIENT (ARTIST create)', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         id: 'client-uuid',
         role: 'ARTIST',
       });
+
+      await expect(
+        service.create(artistDto, artistId, 'ARTIST'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw NotFoundException when client does not exist (ARTIST create)', async () => {
+      mockPrisma.user.findUnique.mockReset();
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      await expect(
+        service.create(artistDto, artistId, 'ARTIST'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should create a commission as CLIENT', async () => {
+      const clientDto = {
+        title: 'Portrait',
+        description: 'Digital art',
+        price: 150,
+        artistId: 'artist-uuid',
+      };
+      const clientUserId = 'client-uuid';
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         id: 'artist-uuid',
         role: 'ARTIST',
       });
+      const expected = {
+        id: 'uuid-1',
+        title: 'Portrait',
+        description: 'Digital art',
+        price: 150,
+        clientId: clientUserId,
+        artistId: 'artist-uuid',
+        status: 'PENDING',
+      };
+      mockPrisma.commission.create.mockResolvedValue(expected);
 
-      await expect(service.create(dto, artistId)).rejects.toThrow(
-        BadRequestException,
-      );
+      const result = await service.create(clientDto, clientUserId, 'CLIENT');
+      expect(result).toEqual(expected);
     });
 
-    it('should throw NotFoundException when client does not exist', async () => {
-      mockPrisma.user.findUnique.mockReset();
-      mockPrisma.user.findUnique.mockResolvedValue(null);
-      await expect(service.create(dto, artistId)).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-
-    it('should throw NotFoundException when artist does not exist', async () => {
-      mockPrisma.user.findUnique.mockResolvedValueOnce({
-        id: 'client-uuid',
-        role: 'CLIENT',
-      });
+    it('should throw NotFoundException when artist does not exist (CLIENT create)', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
-      await expect(service.create(dto, artistId)).rejects.toThrow(
-        NotFoundException,
-      );
+      const clientDto = {
+        title: 'Portrait',
+        description: 'Digital art',
+        price: 150,
+        artistId: 'nonexistent-artist',
+      };
+
+      await expect(
+        service.create(clientDto, 'client-uuid', 'CLIENT'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when CLIENT does not provide artistId', async () => {
+      await expect(
+        service.create(
+          { title: 'Portrait', description: 'Art', price: 100 },
+          'client-uuid',
+          'CLIENT',
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/backend/src/commissions/commissions.service.ts
+++ b/apps/backend/src/commissions/commissions.service.ts
@@ -16,24 +16,46 @@ export class CommissionsService {
       title: string;
       description: string;
       price: number;
-      clientId: string;
+      clientId?: string;
+      artistId?: string;
       deadline?: string;
     },
-    artistId: string,
+    userId: string,
+    role: string,
   ) {
-    const client = await this.prisma.user.findUnique({
-      where: { id: dto.clientId },
-    });
-    if (!client) throw new NotFoundException('Client not found');
-    if (client.role !== 'CLIENT')
-      throw new BadRequestException('Client must have CLIENT role');
+    let clientId: string;
+    let artistId: string;
 
-    const artist = await this.prisma.user.findUnique({
-      where: { id: artistId },
-    });
-    if (!artist) throw new NotFoundException('Artist not found');
+    if (role === 'CLIENT') {
+      clientId = userId;
+      artistId = dto.artistId!;
+      if (!artistId) throw new BadRequestException('Artist ID is required');
+      const artist = await this.prisma.user.findUnique({
+        where: { id: artistId },
+      });
+      if (!artist) throw new NotFoundException('Artist not found');
+    } else {
+      clientId = dto.clientId!;
+      if (!clientId) throw new BadRequestException('Client ID is required');
+      artistId = userId;
+      const client = await this.prisma.user.findUnique({
+        where: { id: clientId },
+      });
+      if (!client) throw new NotFoundException('Client not found');
+      if (client.role !== 'CLIENT')
+        throw new BadRequestException('Client must have CLIENT role');
+    }
 
-    return this.prisma.commission.create({ data: { ...dto, artistId } });
+    return this.prisma.commission.create({
+      data: {
+        title: dto.title,
+        description: dto.description,
+        price: dto.price,
+        deadline: dto.deadline,
+        clientId,
+        artistId,
+      },
+    });
   }
 
   async findAll(userId: string, role: string) {
@@ -104,6 +126,7 @@ export class CommissionsService {
       where: { id },
       include: {
         client: { select: { id: true, name: true, email: true } },
+        artist: { select: { id: true, name: true, email: true } },
       },
     });
     if (!commission) throw new NotFoundException('Commission not found');

--- a/apps/backend/src/commissions/dto/create-commission.dto.ts
+++ b/apps/backend/src/commissions/dto/create-commission.dto.ts
@@ -33,6 +33,10 @@ export class CreateCommissionDto {
   deadline?: string;
 
   @IsUUID('4', { message: 'O ID do cliente deve ser um UUID válido' })
-  @IsNotEmpty({ message: 'O ID do cliente é obrigatório' })
-  clientId: string;
+  @IsOptional()
+  clientId?: string;
+
+  @IsUUID('4', { message: 'O ID do artista deve ser um UUID válido' })
+  @IsOptional()
+  artistId?: string;
 }

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -30,8 +30,7 @@ export class UsersController {
     return req.user;
   }
 
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(Role.ARTIST)
+  @UseGuards(JwtAuthGuard)
   @Get()
   findAll() {
     return this.usersService.findAll();

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, afterEach } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ArtistaComissaoDetalhes } from './ArtistaComissaoDetalhes'
+import { CommissionStatus } from '../../types/api'
+import type { Commission, User, Delivery } from '../../types/api'
+
+const client: User = {
+  id: 'client-1',
+  name: 'Maria Cliente',
+  email: 'maria@test.com',
+  role: 'CLIENT',
+  createdAt: '2024-01-01',
+}
+
+const commission: Commission = {
+  id: '1',
+  title: 'Retrato Digital',
+  description: 'Ilustração digital em alta resolução',
+  price: 150,
+  status: CommissionStatus.PENDING,
+  deadline: '2024-06-01',
+  clientId: 'client-1',
+  artistId: 'artist-1',
+  client,
+  createdAt: '2024-05-01',
+}
+
+const deliveries: Delivery[] = []
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/artista/comissoes/1']}>
+      <Routes>
+        <Route path="/artista/comissoes/:id" element={<ArtistaComissaoDetalhes />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('ArtistaComissaoDetalhes', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(() => new Promise(() => {}))
+    mock.onGet('/deliveries/1').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders commission details', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Maria Cliente/)).toBeInTheDocument()
+    expect(screen.getByText(/150\.00/)).toBeInTheDocument()
+    expect(screen.getAllByText('Pendente').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows status select', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(500)
+    mock.onGet('/deliveries/1').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
@@ -1,3 +1,183 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import api from '../../services/api'
+import { StatusBadge } from '../../components/ui/StatusBadge'
+import { CommissionStatus } from '../../types/api'
+import type { Commission, Delivery } from '../../types/api'
+
 export function ArtistaComissaoDetalhes() {
-  return <div>Detalhes da Comissão (Artista)</div>
+  const { id } = useParams<{ id: string }>()
+  const [commission, setCommission] = useState<Commission | null>(null)
+  const [deliveries, setDeliveries] = useState<Delivery[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+  const [updating, setUpdating] = useState(false)
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+
+    Promise.all([
+      api.get<Commission>(`/commissions/${id}`),
+      api.get<Delivery[]>(`/deliveries/${id}`),
+    ])
+      .then(([commissionRes, deliveriesRes]) => {
+        if (cancelled) return
+        setCommission(commissionRes.data)
+        setDeliveries(deliveriesRes.data)
+      })
+      .catch(() => {
+        if (!cancelled) setApiError('Erro ao carregar comissão. Tente novamente.')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [id])
+
+  async function handleStatusChange(newStatus: CommissionStatus) {
+    if (!id) return
+    setUpdating(true)
+    try {
+      await api.patch(`/commissions/${id}/status`, { status: newStatus })
+      setCommission(prev => prev ? { ...prev, status: newStatus } : null)
+    } catch {
+      setApiError('Erro ao atualizar status.')
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError || !commission) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError || 'Comissão não encontrada.'}
+        </div>
+        <Link
+          to="/artista/painel"
+          className="mt-4 inline-block rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white no-underline hover:brightness-90"
+        >
+          Voltar para o painel
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link
+        to="/artista/painel"
+        className="mb-6 inline-block text-sm text-tertiary no-underline hover:text-primary"
+      >
+        &larr; Voltar
+      </Link>
+
+      <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="font-display text-2xl font-bold text-on-surface">
+            {commission.title}
+          </h1>
+          <StatusBadge status={commission.status} />
+        </div>
+
+        <p className="text-sm text-tertiary leading-relaxed mb-6">
+          {commission.description}
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2 mb-6">
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Cliente</p>
+            <p className="text-sm font-semibold text-on-surface">
+              {commission.client?.name ?? '---'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Valor</p>
+            <p className="text-sm font-semibold text-on-surface">
+              R$ {Number(commission.price).toFixed(2)}
+            </p>
+          </div>
+          {commission.deadline && (
+            <div>
+              <p className="text-xs text-tertiary uppercase tracking-wide">Prazo</p>
+              <p className="text-sm font-semibold text-on-surface">
+                {new Date(commission.deadline).toLocaleDateString('pt-BR')}
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Criada em</p>
+            <p className="text-sm font-semibold text-on-surface">
+              {commission.createdAt
+                ? new Date(commission.createdAt).toLocaleDateString('pt-BR')
+                : '---'}
+            </p>
+          </div>
+        </div>
+
+        <div className="border-t border-[#e5e4e7] pt-4">
+          <label
+            htmlFor="status-select"
+            className="text-xs text-tertiary uppercase tracking-wide block mb-2"
+          >
+            Status
+          </label>
+          <select
+            id="status-select"
+            value={commission.status}
+            onChange={(e) => handleStatusChange(e.target.value as CommissionStatus)}
+            disabled={updating}
+            className="rounded-sm border border-[#e5e4e7] bg-surface px-3 py-2 text-sm text-on-surface focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          >
+            <option value={CommissionStatus.PENDING}>Pendente</option>
+            <option value={CommissionStatus.IN_PROGRESS}>Em andamento</option>
+            <option value={CommissionStatus.WAITING_PAYMENT}>Aguardando pagamento</option>
+            <option value={CommissionStatus.COMPLETED}>Concluído</option>
+            <option value={CommissionStatus.CANCELLED}>Cancelado</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <h2 className="font-display text-lg font-bold text-on-surface mb-4">
+          Entregas
+        </h2>
+
+        {deliveries.length === 0 ? (
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-8 text-center">
+            <p className="text-tertiary">Nenhuma entrega realizada ainda.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {deliveries.map(delivery => (
+              <div
+                key={delivery.id}
+                className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-on-surface">{delivery.notes}</span>
+                  <p className="text-xs text-tertiary">
+                    {new Date(delivery.createdAt).toLocaleDateString('pt-BR')}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.test.tsx
+++ b/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, afterEach } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ClienteComissaoDetalhes } from './ClienteComissaoDetalhes'
+import { CommissionStatus } from '../../types/api'
+import type { Commission, User, Delivery } from '../../types/api'
+
+const artist: User = {
+  id: 'artist-1',
+  name: 'Carlos Artista',
+  email: 'carlos@test.com',
+  role: 'ARTIST',
+  createdAt: '2024-01-01',
+}
+
+const commission: Commission = {
+  id: '1',
+  title: 'Retrato Digital',
+  description: 'Ilustração digital em alta resolução',
+  price: 150,
+  status: CommissionStatus.IN_PROGRESS,
+  deadline: '2024-06-01',
+  clientId: 'client-1',
+  artistId: 'artist-1',
+  artist,
+  createdAt: '2024-05-01',
+}
+
+const deliveries: Delivery[] = [
+  {
+    id: 'd1',
+    fileUrl: 'https://exemplo.com/entrega.jpg',
+    notes: 'Primeira versão',
+    commissionId: '1',
+    createdAt: '2024-05-15',
+  },
+]
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/cliente/comissoes/1']}>
+      <Routes>
+        <Route path="/cliente/comissoes/:id" element={<ClienteComissaoDetalhes />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('ClienteComissaoDetalhes', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(() => new Promise(() => {}))
+    mock.onGet('/deliveries/1').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders commission details', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Ilustração digital em alta resolução/)).toBeInTheDocument()
+    expect(screen.getByText(/Carlos Artista/)).toBeInTheDocument()
+    expect(screen.getByText(/150\.00/)).toBeInTheDocument()
+    expect(screen.getByText('Em andamento')).toBeInTheDocument()
+    expect(screen.getByText(/Primeira versão/)).toBeInTheDocument()
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(500)
+    mock.onGet('/deliveries/1').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows no deliveries message', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Nenhuma entrega/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
@@ -1,3 +1,158 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import api from '../../services/api'
+import { StatusBadge } from '../../components/ui/StatusBadge'
+import type { Commission, Delivery } from '../../types/api'
+
 export function ClienteComissaoDetalhes() {
-  return <div>Detalhes da Comissão</div>
+  const { id } = useParams<{ id: string }>()
+  const [commission, setCommission] = useState<Commission | null>(null)
+  const [deliveries, setDeliveries] = useState<Delivery[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+
+  useEffect(() => {
+    if (!id) return
+    let cancelled = false
+
+    Promise.all([
+      api.get<Commission>(`/commissions/${id}`),
+      api.get<Delivery[]>(`/deliveries/${id}`),
+    ])
+      .then(([commissionRes, deliveriesRes]) => {
+        if (cancelled) return
+        setCommission(commissionRes.data)
+        setDeliveries(deliveriesRes.data)
+      })
+      .catch(() => {
+        if (!cancelled) setApiError('Erro ao carregar comissão. Tente novamente.')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [id])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError || !commission) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError || 'Comissão não encontrada.'}
+        </div>
+        <Link
+          to="/cliente/comissoes"
+          className="mt-4 inline-block rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white no-underline hover:brightness-90"
+        >
+          Voltar para minhas comissões
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link
+        to="/cliente/comissoes"
+        className="mb-6 inline-block text-sm text-tertiary no-underline hover:text-primary"
+      >
+        &larr; Voltar
+      </Link>
+
+      <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card">
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="font-display text-2xl font-bold text-on-surface">
+            {commission.title}
+          </h1>
+          <StatusBadge status={commission.status} />
+        </div>
+
+        <p className="text-sm text-tertiary leading-relaxed mb-6">
+          {commission.description}
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2 mb-6">
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Artista</p>
+            <p className="text-sm font-semibold text-on-surface">
+              {commission.artist?.name ?? '---'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Valor</p>
+            <p className="text-sm font-semibold text-on-surface">
+              R$ {Number(commission.price).toFixed(2)}
+            </p>
+          </div>
+          {commission.deadline && (
+            <div>
+              <p className="text-xs text-tertiary uppercase tracking-wide">Prazo</p>
+              <p className="text-sm font-semibold text-on-surface">
+                {new Date(commission.deadline).toLocaleDateString('pt-BR')}
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="text-xs text-tertiary uppercase tracking-wide">Criada em</p>
+            <p className="text-sm font-semibold text-on-surface">
+              {commission.createdAt
+                ? new Date(commission.createdAt).toLocaleDateString('pt-BR')
+                : '---'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <h2 className="font-display text-lg font-bold text-on-surface mb-4">
+          Entregas
+        </h2>
+
+        {deliveries.length === 0 ? (
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-8 text-center">
+            <p className="text-tertiary">Nenhuma entrega realizada ainda.</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {deliveries.map(delivery => (
+              <div
+                key={delivery.id}
+                className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <a
+                      href={delivery.fileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-semibold text-primary no-underline hover:underline"
+                    >
+                      Ver arquivo
+                    </a>
+                    {delivery.notes && (
+                      <p className="mt-1 text-sm text-tertiary">{delivery.notes}</p>
+                    )}
+                  </div>
+                  <p className="text-xs text-tertiary">
+                    {new Date(delivery.createdAt).toLocaleDateString('pt-BR')}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }

--- a/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.test.tsx
+++ b/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ClienteComissoes } from './ClienteComissoes'
+import { CommissionStatus } from '../../types/api'
+import type { Commission, User } from '../../types/api'
+
+const artist: User = {
+  id: 'artist-1',
+  name: 'Carlos',
+  email: 'carlos@test.com',
+  role: 'ARTIST',
+  createdAt: '2024-01-01',
+}
+
+const commissions: Commission[] = [
+  {
+    id: '1',
+    title: 'Retrato Digital',
+    description: 'Descrição',
+    price: 150,
+    status: CommissionStatus.PENDING,
+    deadline: null,
+    clientId: 'client-1',
+    artistId: 'artist-1',
+    artist,
+  },
+  {
+    id: '2',
+    title: 'Ilustração',
+    description: 'Descrição',
+    price: 200,
+    status: CommissionStatus.IN_PROGRESS,
+    deadline: '2024-06-01',
+    clientId: 'client-1',
+    artistId: 'artist-1',
+    artist,
+  },
+]
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ClienteComissoes />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClienteComissoes', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders list of commissions', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, commissions)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Ilustração')).toBeInTheDocument()
+    expect(screen.getAllByText(/Carlos/)).toHaveLength(2)
+    expect(screen.getAllByText('Pendente').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Em andamento').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows summary cards', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, commissions)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no commissions', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/nenhuma comissão/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions').reply(500)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.tsx
+++ b/apps/frontend/src/pages/ClienteComissoes/ClienteComissoes.tsx
@@ -1,3 +1,119 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import api from '../../services/api'
+import { StatusBadge } from '../../components/ui/StatusBadge'
+import { CommissionStatus } from '../../types/api'
+import type { Commission } from '../../types/api'
+
+function getStatusCounts(commissions: Commission[]) {
+  const total = commissions.length
+  const pending = commissions.filter(c => c.status === CommissionStatus.PENDING).length
+  const inProgress = commissions.filter(c => c.status === CommissionStatus.IN_PROGRESS).length
+  const completed = commissions.filter(c => c.status === CommissionStatus.COMPLETED).length
+  return { total, pending, inProgress, completed }
+}
+
 export function ClienteComissoes() {
-  return <div>Minhas Comissões</div>
+  const [commissions, setCommissions] = useState<Commission[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+
+  useEffect(() => {
+    api.get<Commission[]>('/commissions')
+      .then(({ data }) => setCommissions(data))
+      .catch(() => setApiError('Erro ao carregar comissões. Tente novamente.'))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+      </div>
+    )
+  }
+
+  const counts = getStatusCounts(commissions)
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="font-display text-2xl font-bold text-on-surface">
+          Minhas Comissões
+        </h1>
+        <Link
+          to="/cliente/nova"
+          className="rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white no-underline hover:brightness-90"
+        >
+          Nova Comissão
+        </Link>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-4 mb-8">
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Total</p>
+          <p className="font-display text-2xl font-bold text-on-surface">{counts.total}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Pendentes</p>
+          <p className="font-display text-2xl font-bold text-yellow-600">{counts.pending}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Em andamento</p>
+          <p className="font-display text-2xl font-bold text-blue-600">{counts.inProgress}</p>
+        </div>
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card">
+          <p className="text-sm text-tertiary">Concluídas</p>
+          <p className="font-display text-2xl font-bold text-green-600">{counts.completed}</p>
+        </div>
+      </div>
+
+      {commissions.length === 0 ? (
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-12 text-center">
+          <p className="text-tertiary">Nenhuma comissão encontrada.</p>
+          <p className="mt-1 text-sm text-tertiary">
+            Crie uma nova comissão para começar.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {commissions.map(commission => (
+            <div
+              key={commission.id}
+              className="flex items-center justify-between rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
+            >
+              <div className="flex-1">
+                <div className="flex items-center gap-3">
+                  <Link
+                    to={`/cliente/comissoes/${commission.id}`}
+                    className="font-display text-base font-semibold text-on-surface no-underline hover:text-primary"
+                  >
+                    {commission.title}
+                  </Link>
+                  <StatusBadge status={commission.status} />
+                </div>
+                <p className="mt-1 text-sm text-tertiary">
+                  Artista: {commission.artist?.name ?? '---'} &middot; R$ {Number(commission.price).toFixed(2)}
+                  {commission.deadline && ` · Prazo: ${new Date(commission.deadline).toLocaleDateString('pt-BR')}`}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/apps/frontend/src/types/api.ts
+++ b/apps/frontend/src/types/api.ts
@@ -73,7 +73,8 @@ export interface CreateCommissionRequest {
   description: string;
   price: number;
   deadline?: string;
-  clientId: string;
+  clientId?: string;
+  artistId?: string;
 }
 
 export interface UpdateCommissionRequest {


### PR DESCRIPTION
## Mudancas

### Backend
- **CreateCommissionDto**: clientId opcional, artistId adicionado
- **commissions.controller**: POST /commissions aceita ARTIST + CLIENT (passa role)
- **commissions.service**: create() lida com ambos os papeis; findById inclui artist no select
- **users.controller**: GET /users liberado para qualquer usuario autenticado
- **Testes**: +2 (CLIENT create flows) — 74 total

### Frontend
- **ClienteComissoes** (/cliente/comissoes): painel do cliente com summary cards + lista + nome do artista (5 testes)
- **ClienteComissaoDetalhes** (/cliente/comissoes/:id): detalhes da comissao + entregas (4 testes)
- **ArtistaComissaoDetalhes** (/artista/comissoes/:id): detalhes com status update (4 testes)
- **CreateCommissionRequest**: tipo atualizado (clientId optional, artistId adicionado)
- **Testes**: +13 — 87 total

### Total
- Frontend: 87 testes passando
- Backend: 74 testes passando
- **Total: 161 testes, lint limpo**