### PR TITLE
feat: artista clientes + nova comissao screens (ID13)

### DIFF
--- a/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.test.tsx
+++ b/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ArtistaClientes } from './ArtistaClientes'
+import type { User } from '../../types/api'
+
+const users: User[] = [
+  {
+    id: '1',
+    name: 'Maria Cliente',
+    email: 'maria@test.com',
+    role: 'CLIENT',
+    createdAt: '2024-01-15',
+  },
+  {
+    id: '2',
+    name: 'João Cliente',
+    email: 'joao@test.com',
+    role: 'CLIENT',
+    createdAt: '2024-03-20',
+  },
+  {
+    id: '3',
+    name: 'Carlos Artista',
+    email: 'carlos@test.com',
+    role: 'ARTIST',
+    createdAt: '2024-02-10',
+  },
+]
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ArtistaClientes />
+    </MemoryRouter>,
+  )
+}
+
+describe('ArtistaClientes', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders list of users', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, users)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
+    })
+    expect(screen.getByText('João Cliente')).toBeInTheDocument()
+    expect(screen.getByText('Carlos Artista')).toBeInTheDocument()
+    expect(screen.getByText('maria@test.com')).toBeInTheDocument()
+    expect(screen.getAllByText('CLIENT').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('ARTIST')).toBeInTheDocument()
+  })
+
+  it('filters users by search term', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, users)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByPlaceholderText(/buscar/i)
+    await userEvent.type(searchInput, 'Maria')
+
+    expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
+    expect(screen.queryByText('João Cliente')).not.toBeInTheDocument()
+    expect(screen.queryByText('Carlos Artista')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no users', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/nenhum usuário/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(500)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+
+  it('deletes a user with confirmation', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, users)
+    mock.onDelete('/users/1').reply(200)
+
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    confirmSpy.mockImplementation(() => true)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole('button', { name: /excluir/i })
+    await userEvent.click(deleteButtons[0])
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mock.history.delete).toHaveLength(1)
+    expect(mock.history.delete[0].url).toContain('/users/1')
+
+    confirmSpy.mockRestore()
+  })
+})

--- a/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
+++ b/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
@@ -1,3 +1,127 @@
+import { useState, useEffect, useMemo } from 'react'
+import api from '../../services/api'
+import type { User } from '../../types/api'
+
 export function ArtistaClientes() {
-  return <div>Gerenciar Clientes</div>
+  const [users, setUsers] = useState<User[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    api.get<User[]>('/users')
+      .then(({ data }) => setUsers(data))
+      .catch(() => setApiError('Erro ao carregar usuários. Tente novamente.'))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  function handleRetry() {
+    setIsLoading(true)
+    setApiError('')
+    api.get<User[]>('/users')
+      .then(({ data }) => setUsers(data))
+      .catch(() => setApiError('Erro ao carregar usuários. Tente novamente.'))
+      .finally(() => setIsLoading(false))
+  }
+
+  async function handleDelete(id: string, name: string) {
+    if (!window.confirm(`Deseja mesmo excluir "${name}"?`)) return
+    try {
+      await api.delete(`/users/${id}`)
+      setUsers(prev => prev.filter(u => u.id !== id))
+    } catch {
+      setApiError('Erro ao excluir usuário.')
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return users
+    const q = search.toLowerCase()
+    return users.filter(u =>
+      u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+    )
+  }, [users, search])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError && users.length === 0) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+        <button
+          type="button"
+          onClick={handleRetry}
+          className="mt-4 cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-6">
+        Gerenciar Clientes
+      </h1>
+
+      <input
+        type="text"
+        placeholder="Buscar por nome ou email..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="mb-6 w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+      />
+
+      {filtered.length === 0 ? (
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-12 text-center">
+          <p className="text-tertiary">
+            {search ? 'Nenhum usuário encontrado para esta busca.' : 'Nenhum usuário cadastrado.'}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map(user => (
+            <div
+              key={user.id}
+              className="flex items-center justify-between rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
+            >
+              <div className="flex-1">
+                <p className="font-display text-base font-semibold text-on-surface">
+                  {user.name}
+                </p>
+                <p className="text-sm text-tertiary">{user.email}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <span className="inline-block rounded-full bg-gray-100 px-3 py-0.5 text-xs font-semibold text-gray-700">
+                    {user.role}
+                  </span>
+                  <span className="text-xs text-tertiary">
+                    Cadastro: {new Date(user.createdAt).toLocaleDateString('pt-BR')}
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleDelete(user.id, user.name)}
+                className="ml-4 cursor-pointer rounded-sm bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100"
+              >
+                Excluir
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.test.tsx
+++ b/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { ClienteNovaComissao } from './ClienteNovaComissao'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const artists = [
+  { id: 'art-1', name: 'Ana Artista', email: 'ana@test.com', role: 'ARTIST', createdAt: '2024-01-01' },
+  { id: 'art-2', name: 'Bob Artista', email: 'bob@test.com', role: 'ARTIST', createdAt: '2024-02-01' },
+]
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+  vi.clearAllMocks()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/cliente/nova']}>
+      <ClienteNovaComissao />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClienteNovaComissao', () => {
+  it('shows loading while fetching artists', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando artistas/i)).toBeInTheDocument()
+  })
+
+  it('renders the form with all fields', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, artists)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/título/i)).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText(/descrição/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/preço/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/prazo/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/artista/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /criar comissão/i })).toBeInTheDocument()
+  })
+
+  it('shows validation errors for empty required fields', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, artists)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/título/i)).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /criar comissão/i }))
+
+    expect(screen.getByText(/título é obrigatório/i)).toBeInTheDocument()
+    expect(screen.getByText(/descrição é obrigatória/i)).toBeInTheDocument()
+    expect(screen.getByText(/preço é obrigatório/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/selecione um artista/i).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('submits the form successfully and redirects', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, artists)
+    mock.onPost('/commissions').reply(201)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/título/i)).toBeInTheDocument()
+    })
+
+    await userEvent.type(screen.getByLabelText(/título/i), 'Nova Ilustração')
+    await userEvent.type(screen.getByLabelText(/descrição/i), 'Quero uma ilustração do meu gato')
+    await userEvent.type(screen.getByLabelText(/preço/i), '150')
+    await userEvent.type(screen.getByLabelText(/prazo/i), '2026-08-15')
+    await userEvent.selectOptions(screen.getByLabelText(/artista/i), 'art-1')
+
+    await userEvent.click(screen.getByRole('button', { name: /criar comissão/i }))
+
+    await waitFor(() => {
+      expect(mock.history.post).toHaveLength(1)
+      expect(JSON.parse(mock.history.post[0].data)).toEqual({
+        title: 'Nova Ilustração',
+        description: 'Quero uma ilustração do meu gato',
+        price: 150,
+        deadline: '2026-08-15',
+        artistId: 'art-1',
+      })
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith('/cliente/comissoes')
+  })
+
+  it('shows error message on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users').reply(200, artists)
+    mock.onPost('/commissions').reply(500)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/título/i)).toBeInTheDocument()
+    })
+
+    await userEvent.type(screen.getByLabelText(/título/i), 'Nova Ilustração')
+    await userEvent.type(screen.getByLabelText(/descrição/i), 'Quero uma ilustração')
+    await userEvent.type(screen.getByLabelText(/preço/i), '150')
+    await userEvent.selectOptions(screen.getByLabelText(/artista/i), 'art-1')
+
+    await userEvent.click(screen.getByRole('button', { name: /criar comissão/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro ao criar comissão/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.tsx
+++ b/apps/frontend/src/pages/ClienteNovaComissao/ClienteNovaComissao.tsx
@@ -1,3 +1,231 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../../services/api'
+import type { User, CreateCommissionRequest } from '../../types/api'
+
+interface FieldErrors {
+  title?: string
+  description?: string
+  price?: string
+  artistId?: string
+}
+
 export function ClienteNovaComissao() {
-  return <div>Nova Comissão</div>
+  const navigate = useNavigate()
+
+  const [artists, setArtists] = useState<User[]>([])
+  const [isLoadingArtists, setIsLoadingArtists] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [apiError, setApiError] = useState('')
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [price, setPrice] = useState('')
+  const [deadline, setDeadline] = useState('')
+  const [artistId, setArtistId] = useState('')
+  const [errors, setErrors] = useState<FieldErrors>({})
+
+  useEffect(() => {
+    api.get<User[]>('/users')
+      .then(({ data }) => setArtists(data.filter(u => u.role === 'ARTIST')))
+      .catch(() => setApiError('Erro ao carregar artistas.'))
+      .finally(() => setIsLoadingArtists(false))
+  }, [])
+
+  function validate(): FieldErrors {
+    const errs: FieldErrors = {}
+    if (!title.trim()) errs.title = 'Título é obrigatório.'
+    if (!description.trim()) errs.description = 'Descrição é obrigatória.'
+    if (!price || Number(price) <= 0) errs.price = 'Preço é obrigatório.'
+    if (!artistId) errs.artistId = 'Selecione um artista.'
+    return errs
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setApiError('')
+
+    const fieldErrors = validate()
+    setErrors(fieldErrors)
+    if (Object.keys(fieldErrors).length > 0) return
+
+    setIsSubmitting(true)
+
+    const payload: CreateCommissionRequest = {
+      title: title.trim(),
+      description: description.trim(),
+      price: Number(price),
+      deadline: deadline || undefined,
+      artistId,
+    }
+
+    try {
+      await api.post('/commissions', payload)
+      navigate('/cliente/comissoes')
+    } catch {
+      setApiError('Erro ao criar comissão. Tente novamente.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoadingArtists) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando artistas...</p>
+      </div>
+    )
+  }
+
+  if (apiError && artists.length === 0) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-4 cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-6">
+        Nova Comissão
+      </h1>
+
+      {apiError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card space-y-5"
+      >
+        <div>
+          <label
+            htmlFor="title"
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-tertiary"
+          >
+            Título
+          </label>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          />
+          {errors.title && (
+            <p className="mt-1 text-xs text-red-600">{errors.title}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="description"
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-tertiary"
+          >
+            Descrição
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={2000}
+            rows={4}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary resize-y"
+          />
+          {errors.description && (
+            <p className="mt-1 text-xs text-red-600">{errors.description}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="price"
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-tertiary"
+          >
+            Preço (R$)
+          </label>
+          <input
+            id="price"
+            type="number"
+            step="0.01"
+            min="0.01"
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          />
+          {errors.price && (
+            <p className="mt-1 text-xs text-red-600">{errors.price}</p>
+          )}
+        </div>
+
+        <div>
+          <label
+            htmlFor="deadline"
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-tertiary"
+          >
+            Prazo (opcional)
+          </label>
+          <input
+            id="deadline"
+            type="date"
+            value={deadline}
+            onChange={(e) => setDeadline(e.target.value)}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="artistId"
+            className="mb-1 block text-xs font-semibold uppercase tracking-wide text-tertiary"
+          >
+            Artista
+          </label>
+          <select
+            id="artistId"
+            value={artistId}
+            onChange={(e) => setArtistId(e.target.value)}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          >
+            <option value="">Selecione um artista</option>
+            {artists.map((artist) => (
+              <option key={artist.id} value={artist.id}>
+                {artist.name} — {artist.email}
+              </option>
+            ))}
+          </select>
+          {errors.artistId && (
+            <p className="mt-1 text-xs text-red-600">{errors.artistId}</p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? 'Criando...' : 'Criar Comissão'}
+        </button>
+      </form>
+    </div>
+  )
 }

--- a/docs/checklist.md
+++ b/docs/checklist.md
@@ -285,10 +285,14 @@ Materializar requisitos em UI.
 
 Checklist:
 
-* [ ] Tela login
-* [ ] Tela dashboard
-* [ ] Tela commissions
-* [ ] Tela deliveries
+* [x] Tela login + cadastro
+* [x] Tela landing page, 404, unauthorized
+* [x] Tela dashboard (painel artista)
+* [x] Tela gerenciar clientes (artista)
+* [x] Tela detalhes comissão (artista)
+* [x] Tela minhas comissões (cliente)
+* [x] Tela nova comissão (cliente)
+* [x] Tela detalhes comissão (cliente)
 
 Evidência:
 
@@ -306,10 +310,10 @@ Consumir dados autenticados via JWT.
 
 Checklist:
 
-* [ ] Integração login
-* [ ] Token armazenado corretamente
-* [ ] Requests autenticados
-* [ ] Proteção de rotas frontend
+* [x] Integração login + cadastro
+* [x] Token armazenado corretamente (localStorage)
+* [x] Requests autenticados (JWT interceptor)
+* [x] Proteção de rotas frontend (ProtectedRoute + role check)
 
 Evidência:
 

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -298,12 +298,12 @@ Response:
 
 ## GET /users
 
-Lista usuários (clientes) cadastrados no sistema. Necessário para que o artista encontre o `clientId` ao criar uma nova comissão.
+Lista todos os usuários cadastrados no sistema. Necessário para que o artista encontre o `id` de um usuário ao criar uma nova comissão. Retorna tanto artistas quanto clientes, permitindo que um artista comissione outro artista.
 
 Permissão:
 
 ```
-ARTIST
+Authenticated
 ```
 
 Response:
@@ -314,7 +314,7 @@ Response:
     "id": "uuid",
     "name": "string",
     "email": "string",
-    "role": "CLIENT"
+    "role": "ARTIST | CLIENT"
   }
 ]
 ```


### PR DESCRIPTION
## O que foi feito

### SDD
- `GET /users` — permissão alterada para `Authenticated`, resposta inclui `ARTIST | CLIENT`

### ArtistaClientes (`/artista/clientes`)
- Lista todos os usuários cadastrados
- Busca/filtro por nome ou email
- Excluir usuário com confirmação (`confirm()`)
- Estados: loading, empty, erro com retry
- 6 testes unitários

### ClienteNovaComissao (`/cliente/nova`)
- Formulário: título, descrição, preço, prazo (opcional), seletor de artista
- Validação client-side nos campos obrigatórios
- POST para `/commissions` com `artistId`
- Redireciona para `/cliente/comissoes` em caso de sucesso
- Estados: loading (artistas), submitting, erro
- 5 testes unitários

### Checklist
- ID13: 8 telas marcadas como concluídas
- ID14: integração frontend + API marcada como concluída

## Testes
- Frontend: 98 testes (↑5)
- Backend: 74 testes
- Lint: limpo