### PR TITLE
feat: delivery form + user profile page (ID13)

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { ArtistaComissaoDetalhes } from './pages/ArtistaComissaoDetalhes/Artista
 import { ClienteComissoes } from './pages/ClienteComissoes/ClienteComissoes'
 import { ClienteNovaComissao } from './pages/ClienteNovaComissao/ClienteNovaComissao'
 import { ClienteComissaoDetalhes } from './pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes'
+import { Perfil } from './pages/Perfil/Perfil'
 
 function App() {
   return (
@@ -26,6 +27,10 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/cadastro" element={<Cadastro />} />
             <Route path="/unauthorized" element={<Unauthorized />} />
+
+            <Route element={<ProtectedRoute allowedRoles={[Role.ARTIST, Role.CLIENT]} />}>
+              <Route path="/perfil" element={<Perfil />} />
+            </Route>
 
             <Route element={<ProtectedRoute allowedRoles={[Role.ARTIST]} />}>
               <Route path="/artista/painel" element={<ArtistaPainel />} />

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -63,7 +63,12 @@ export function Header() {
                 </Link>
               )}
 
-              <span className="text-sm text-tertiary">{user.name}</span>
+              <Link
+                to="/perfil"
+                className="text-sm font-medium text-tertiary no-underline hover:text-on-surface transition-colors"
+              >
+                {user.name}
+              </Link>
               <button
                 type="button"
                 onClick={handleLogout}

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, afterEach } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'
@@ -92,6 +93,74 @@ describe('ArtistaComissaoDetalhes', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/erro/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows delivery form with fileUrl and notes fields', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+
+    expect(screen.getByPlaceholderText(/url do arquivo/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/observações/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /adicionar entrega/i })).toBeInTheDocument()
+  })
+
+  it('creates delivery and updates the list', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+
+    const newDelivery: Delivery = {
+      id: 'del-1',
+      fileUrl: 'https://cdn.example.com/art.png',
+      notes: 'Versão final',
+      commissionId: '1',
+      createdAt: '2024-06-01',
+    }
+
+    mock.onPost('/deliveries').reply(201, newDelivery)
+
+    await userEvent.type(screen.getByPlaceholderText(/url do arquivo/i), 'https://cdn.example.com/art.png')
+    await userEvent.type(screen.getByPlaceholderText(/observações/i), 'Versão final')
+    await userEvent.click(screen.getByRole('button', { name: /adicionar entrega/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Versão final')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/ver arquivo/i)).toBeInTheDocument()
+  })
+
+  it('shows error when delivery creation fails', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+
+    mock.onPost('/deliveries').reply(500)
+
+    await userEvent.type(screen.getByPlaceholderText(/url do arquivo/i), 'https://cdn.example.com/art.png')
+    await userEvent.click(screen.getByRole('button', { name: /adicionar entrega/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro ao adicionar entrega/i)).toBeInTheDocument()
     })
   })
 })

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
@@ -12,6 +12,10 @@ export function ArtistaComissaoDetalhes() {
   const [isLoading, setIsLoading] = useState(true)
   const [apiError, setApiError] = useState('')
   const [updating, setUpdating] = useState(false)
+  const [deliveryFileUrl, setDeliveryFileUrl] = useState('')
+  const [deliveryNotes, setDeliveryNotes] = useState('')
+  const [isAddingDelivery, setIsAddingDelivery] = useState(false)
+  const [deliveryError, setDeliveryError] = useState('')
 
   useEffect(() => {
     if (!id) return
@@ -46,6 +50,28 @@ export function ArtistaComissaoDetalhes() {
       setApiError('Erro ao atualizar status.')
     } finally {
       setUpdating(false)
+    }
+  }
+
+  async function handleAddDelivery(e: React.FormEvent) {
+    e.preventDefault()
+    if (!id || !deliveryFileUrl.trim()) return
+    setIsAddingDelivery(true)
+    setDeliveryError('')
+
+    try {
+      const { data } = await api.post<Delivery>('/deliveries', {
+        fileUrl: deliveryFileUrl.trim(),
+        notes: deliveryNotes.trim() || undefined,
+        commissionId: id,
+      })
+      setDeliveries(prev => [...prev, data])
+      setDeliveryFileUrl('')
+      setDeliveryNotes('')
+    } catch {
+      setDeliveryError('Erro ao adicionar entrega.')
+    } finally {
+      setIsAddingDelivery(false)
     }
   }
 
@@ -156,6 +182,36 @@ export function ArtistaComissaoDetalhes() {
           Entregas
         </h2>
 
+        <form
+          onSubmit={handleAddDelivery}
+          className="mb-6 rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card space-y-3"
+        >
+          <input
+            type="text"
+            placeholder="URL do arquivo (obrigatório)"
+            value={deliveryFileUrl}
+            onChange={(e) => setDeliveryFileUrl(e.target.value)}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          />
+          <input
+            type="text"
+            placeholder="Observações (opcional)"
+            value={deliveryNotes}
+            onChange={(e) => setDeliveryNotes(e.target.value)}
+            className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+          />
+          {deliveryError && (
+            <p className="text-xs text-red-600">{deliveryError}</p>
+          )}
+          <button
+            type="submit"
+            disabled={isAddingDelivery || !deliveryFileUrl.trim()}
+            className="cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isAddingDelivery ? 'Adicionando...' : 'Adicionar Entrega'}
+          </button>
+        </form>
+
         {deliveries.length === 0 ? (
           <div className="rounded-sm border border-[#e5e4e7] bg-surface p-8 text-center">
             <p className="text-tertiary">Nenhuma entrega realizada ainda.</p>
@@ -168,7 +224,19 @@ export function ArtistaComissaoDetalhes() {
                 className="rounded-sm border border-[#e5e4e7] bg-surface p-4 shadow-card"
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-sm text-on-surface">{delivery.notes}</span>
+                  <div>
+                    <a
+                      href={delivery.fileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-semibold text-primary no-underline hover:underline"
+                    >
+                      Ver arquivo
+                    </a>
+                    {delivery.notes && (
+                      <p className="mt-1 text-sm text-tertiary">{delivery.notes}</p>
+                    )}
+                  </div>
                   <p className="text-xs text-tertiary">
                     {new Date(delivery.createdAt).toLocaleDateString('pt-BR')}
                   </p>

--- a/apps/frontend/src/pages/Perfil/Perfil.test.tsx
+++ b/apps/frontend/src/pages/Perfil/Perfil.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import api from '../../services/api'
+import { Perfil } from './Perfil'
+import type { User } from '../../types/api'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const mockLogout = vi.fn()
+vi.mock('../../stores/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1', name: 'Maria', email: 'maria@test.com', role: 'CLIENT' },
+    logout: mockLogout,
+  }),
+}))
+
+const userMe: User = {
+  id: 'user-1',
+  name: 'Maria Artista',
+  email: 'maria@test.com',
+  role: 'ARTIST',
+  createdAt: '2024-01-15T10:00:00Z',
+}
+
+let mock: MockAdapter
+
+afterEach(() => {
+  mock?.restore()
+  vi.clearAllMocks()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Perfil />
+    </MemoryRouter>,
+  )
+}
+
+describe('Perfil', () => {
+  it('shows loading state initially', () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users/me').reply(() => new Promise(() => {}))
+
+    renderPage()
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument()
+  })
+
+  it('renders user profile with avatar and info', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users/me').reply(200, userMe)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Artista')).toBeInTheDocument()
+    })
+    expect(screen.getByText('maria@test.com')).toBeInTheDocument()
+    expect(screen.getByText('ARTIST')).toBeInTheDocument()
+
+    expect(screen.getByPlaceholderText(/novo nome/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /editar perfil/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /trocar senha/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /excluir conta/i })).toBeInTheDocument()
+  })
+
+  it('edits user name successfully', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users/me').reply(200, userMe)
+    mock.onPatch('/users/user-1').reply(200, { id: 'user-1', name: 'Novo Nome' })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Artista')).toBeInTheDocument()
+    })
+
+    const input = screen.getByPlaceholderText(/novo nome/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, 'Novo Nome')
+
+    await userEvent.click(screen.getByRole('button', { name: /editar perfil/i }))
+
+    await waitFor(() => {
+      expect(mock.history.patch).toHaveLength(1)
+      expect(JSON.parse(mock.history.patch[0].data)).toEqual({ name: 'Novo Nome' })
+    })
+    expect(screen.getByText('Novo Nome')).toBeInTheDocument()
+  })
+
+  it('deletes account with confirmation and redirects to login', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users/me').reply(200, userMe)
+    mock.onDelete('/users/user-1').reply(200)
+
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    confirmSpy.mockImplementation(() => true)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Artista')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /excluir conta/i }))
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mock.history.delete).toHaveLength(1)
+    expect(mockLogout).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/login')
+
+    confirmSpy.mockRestore()
+  })
+
+  it('shows error on API failure', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/users/me').reply(200, userMe)
+    mock.onPatch('/users/user-1').reply(500)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Maria Artista')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /editar perfil/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro ao atualizar perfil/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/pages/Perfil/Perfil.tsx
+++ b/apps/frontend/src/pages/Perfil/Perfil.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import api from '../../services/api'
+import { useAuth } from '../../stores/AuthContext'
+import type { User } from '../../types/api'
+
+export function Perfil() {
+  const navigate = useNavigate()
+  const { logout } = useAuth()
+
+  const [profile, setProfile] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [apiError, setApiError] = useState('')
+
+  const [editName, setEditName] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    api.get<User>('/users/me')
+      .then(({ data }) => {
+        setProfile(data)
+        setEditName(data.name)
+      })
+      .catch(() => setApiError('Erro ao carregar perfil.'))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  async function handleEditProfile(e: React.FormEvent) {
+    e.preventDefault()
+    if (!profile || !editName.trim()) return
+    setIsSaving(true)
+    setApiError('')
+
+    try {
+      const { data } = await api.patch<User>(`/users/${profile.id}`, { name: editName.trim() })
+      setProfile(prev => prev ? { ...prev, name: data.name } : null)
+    } catch {
+      setApiError('Erro ao atualizar perfil.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleDeleteAccount() {
+    if (!profile) return
+    if (!window.confirm(`Tem certeza que deseja excluir sua conta "${profile.name}"? Esta ação é irreversível.`)) return
+
+    try {
+      await api.delete(`/users/${profile.id}`)
+      logout()
+      navigate('/login')
+    } catch {
+      setApiError('Erro ao excluir conta.')
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <p className="text-tertiary">Carregando...</p>
+      </div>
+    )
+  }
+
+  if (apiError && !profile) {
+    return (
+      <div className="mx-auto mt-16 max-w-md px-4 text-center">
+        <div
+          role="alert"
+          className="rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-4 cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90"
+        >
+          Tentar novamente
+        </button>
+      </div>
+    )
+  }
+
+  if (!profile) return null
+
+  const initials = profile.name
+    .split(' ')
+    .map(w => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <h1 className="font-display text-2xl font-bold text-on-surface mb-8">
+        Meu Perfil
+      </h1>
+
+      {apiError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        >
+          {apiError}
+        </div>
+      )}
+
+      <div className="grid gap-8 md:grid-cols-[1fr_2fr]">
+        <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card text-center">
+          <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-primary text-3xl font-bold text-white">
+            {initials}
+          </div>
+          <h2 className="font-display text-lg font-bold text-on-surface">
+            {profile.name}
+          </h2>
+          <p className="text-sm text-tertiary">{profile.email}</p>
+          <span className="mt-2 inline-block rounded-full bg-gray-100 px-3 py-0.5 text-xs font-semibold text-gray-700">
+            {profile.role}
+          </span>
+          <p className="mt-4 text-xs text-tertiary">
+            Membro desde {new Date(profile.createdAt).toLocaleDateString('pt-BR')}
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <form
+            onSubmit={handleEditProfile}
+            className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card space-y-3"
+          >
+            <h3 className="font-display text-base font-bold text-on-surface">
+              Editar Perfil
+            </h3>
+            <input
+              type="text"
+              placeholder="Novo nome"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              className="w-full rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-on-surface placeholder-tertiary focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+            />
+            <button
+              type="submit"
+              disabled={isSaving || !editName.trim()}
+              className="w-full cursor-pointer rounded-sm bg-primary px-4 py-2 text-sm font-semibold text-white hover:brightness-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSaving ? 'Salvando...' : 'Editar Perfil'}
+            </button>
+          </form>
+
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card space-y-3">
+            <h3 className="font-display text-base font-bold text-on-surface">
+              Segurança
+            </h3>
+            <button
+              type="button"
+              disabled
+              className="w-full cursor-not-allowed rounded-sm border border-[#e5e4e7] bg-surface px-4 py-2 text-sm text-tertiary"
+              title="Em breve"
+            >
+              Trocar Senha
+            </button>
+          </div>
+
+          <div className="rounded-sm border border-[#e5e4e7] bg-surface p-6 shadow-card space-y-3">
+            <h3 className="font-display text-base font-bold text-on-surface">
+              Zona de Perigo
+            </h3>
+            <button
+              type="button"
+              onClick={handleDeleteAccount}
+              className="w-full cursor-pointer rounded-sm bg-red-50 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-100"
+            >
+              Excluir Conta
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## O que foi feito

### Delivery form na tela do artista (/artista/comissoes/:id)
- Formulario no topo da secao "Entregas": campo URL do arquivo (obrigatorio) + Observacoes (opcional)
- POST /deliveries com { fileUrl, notes, commissionId }
- Apos criar, a lista de entregas e atualizada automaticamente
- Delivery list agora exibe link "Ver arquivo" (igual a tela do cliente)
- 3 novos testes (7 total)

### Perfil do usuario (/perfil)
- Rota acessivel para ARTIST e CLIENT
- Painel esquerdo: Avatar circular com iniciais + nome + email + role + "membro desde"
- Painel direito:
  - Editar Perfil: campo nome, PATCH /users/:id
  - Trocar Senha: botao fantasma (desabilitado, placeholder)
  - Excluir Conta: confirm() + DELETE /users/:id + logout + redirect /login
- Nome do usuario no Header agora e link para /perfil
- 5 testes

## Testes
- Frontend: 106 testes (+8)
- Backend: 74 testes
- Lint: limpo
