### PR TITLE
feat: accept/refuse commission + client status banners (ID13)

### DIFF
--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.test.tsx
@@ -72,7 +72,7 @@ describe('ArtistaComissaoDetalhes', () => {
     expect(screen.getAllByText('Pendente').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('shows status select', async () => {
+  it('shows accept and refuse buttons when commission is PENDING', async () => {
     mock = new MockAdapter(api)
     mock.onGet('/commissions/1').reply(200, commission)
     mock.onGet('/deliveries/1').reply(200, deliveries)
@@ -80,8 +80,33 @@ describe('ArtistaComissaoDetalhes', () => {
     renderPage()
 
     await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /aceitar/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /recusar/i })).toBeInTheDocument()
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  it('hides accept/refuse and shows status select after accepting', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+    mock.onPatch('/commissions/1/status').reply(200)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Retrato Digital')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /aceitar/i }))
+
+    await waitFor(() => {
       expect(screen.getByRole('combobox')).toBeInTheDocument()
     })
+    expect(screen.queryByRole('button', { name: /aceitar/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /recusar/i })).not.toBeInTheDocument()
   })
 
   it('shows error message on API failure', async () => {

--- a/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ArtistaComissaoDetalhes/ArtistaComissaoDetalhes.tsx
@@ -155,25 +155,56 @@ export function ArtistaComissaoDetalhes() {
         </div>
 
         <div className="border-t border-[#e5e4e7] pt-4">
-          <label
-            htmlFor="status-select"
-            className="text-xs text-tertiary uppercase tracking-wide block mb-2"
-          >
-            Status
-          </label>
-          <select
-            id="status-select"
-            value={commission.status}
-            onChange={(e) => handleStatusChange(e.target.value as CommissionStatus)}
-            disabled={updating}
-            className="rounded-sm border border-[#e5e4e7] bg-surface px-3 py-2 text-sm text-on-surface focus:outline-2 focus:outline-offset-1 focus:outline-primary"
-          >
-            <option value={CommissionStatus.PENDING}>Pendente</option>
-            <option value={CommissionStatus.IN_PROGRESS}>Em andamento</option>
-            <option value={CommissionStatus.WAITING_PAYMENT}>Aguardando pagamento</option>
-            <option value={CommissionStatus.COMPLETED}>Concluído</option>
-            <option value={CommissionStatus.CANCELLED}>Cancelado</option>
-          </select>
+          {commission.status === CommissionStatus.PENDING ? (
+            <div className="space-y-3">
+              <p className="text-xs text-tertiary uppercase tracking-wide">
+                Responder
+              </p>
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleStatusChange(CommissionStatus.IN_PROGRESS)}
+                  disabled={updating}
+                  className="cursor-pointer rounded-sm bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:brightness-90 disabled:opacity-50"
+                >
+                  {updating ? 'Aceitando...' : 'Aceitar'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (window.confirm('Tem certeza que deseja recusar esta comissão?')) {
+                      handleStatusChange(CommissionStatus.CANCELLED)
+                    }
+                  }}
+                  disabled={updating}
+                  className="cursor-pointer rounded-sm bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:brightness-90 disabled:opacity-50"
+                >
+                  Recusar
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <label
+                htmlFor="status-select"
+                className="text-xs text-tertiary uppercase tracking-wide block mb-2"
+              >
+                Status
+              </label>
+              <select
+                id="status-select"
+                value={commission.status}
+                onChange={(e) => handleStatusChange(e.target.value as CommissionStatus)}
+                disabled={updating}
+                className="rounded-sm border border-[#e5e4e7] bg-surface px-3 py-2 text-sm text-on-surface focus:outline-2 focus:outline-offset-1 focus:outline-primary"
+              >
+                <option value={CommissionStatus.IN_PROGRESS}>Em andamento</option>
+                <option value={CommissionStatus.WAITING_PAYMENT}>Aguardando pagamento</option>
+                <option value={CommissionStatus.COMPLETED}>Concluído</option>
+                <option value={CommissionStatus.CANCELLED}>Cancelado</option>
+              </select>
+            </>
+          )}
         </div>
       </div>
 

--- a/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.test.tsx
+++ b/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.test.tsx
@@ -104,4 +104,44 @@ describe('ClienteComissaoDetalhes', () => {
       expect(screen.getByText(/Nenhuma entrega/i)).toBeInTheDocument()
     })
   })
+
+  it('shows waiting message when commission is PENDING', async () => {
+    const pendingCommission = { ...commission, status: CommissionStatus.PENDING }
+
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, pendingCommission)
+    mock.onGet('/deliveries/1').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/aguardando resposta/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows refused message when commission is CANCELLED', async () => {
+    const cancelledCommission = { ...commission, status: CommissionStatus.CANCELLED }
+
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, cancelledCommission)
+    mock.onGet('/deliveries/1').reply(200, [])
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/recusada/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows accepted message when commission is IN_PROGRESS', async () => {
+    mock = new MockAdapter(api)
+    mock.onGet('/commissions/1').reply(200, commission)
+    mock.onGet('/deliveries/1').reply(200, deliveries)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/aceita/i)).toBeInTheDocument()
+    })
+  })
 })

--- a/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
+++ b/apps/frontend/src/pages/ClienteComissaoDetalhes/ClienteComissaoDetalhes.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import api from '../../services/api'
 import { StatusBadge } from '../../components/ui/StatusBadge'
-import type { Commission, Delivery } from '../../types/api'
+import { CommissionStatus, type Commission, type Delivery } from '../../types/api'
 
 export function ClienteComissaoDetalhes() {
   const { id } = useParams<{ id: string }>()
@@ -81,6 +81,32 @@ export function ClienteComissaoDetalhes() {
         <p className="text-sm text-tertiary leading-relaxed mb-6">
           {commission.description}
         </p>
+
+        {commission.status === CommissionStatus.PENDING && (
+          <div className="mb-4 rounded-sm bg-yellow-50 border border-yellow-200 px-4 py-3 text-sm text-yellow-800">
+            Aguardando resposta do artista...
+          </div>
+        )}
+        {commission.status === CommissionStatus.CANCELLED && (
+          <div className="mb-4 rounded-sm bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+            Comissão recusada pelo artista.
+          </div>
+        )}
+        {commission.status === CommissionStatus.IN_PROGRESS && (
+          <div className="mb-4 rounded-sm bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800">
+            Comissão aceita! O artista já começou a produzir.
+          </div>
+        )}
+        {commission.status === CommissionStatus.WAITING_PAYMENT && (
+          <div className="mb-4 rounded-sm bg-blue-50 border border-blue-200 px-4 py-3 text-sm text-blue-800">
+            Aguardando pagamento...
+          </div>
+        )}
+        {commission.status === CommissionStatus.COMPLETED && (
+          <div className="mb-4 rounded-sm bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800">
+            Comissão concluída!
+          </div>
+        )}
 
         <div className="grid gap-4 sm:grid-cols-2 mb-6">
           <div>


### PR DESCRIPTION
## Alterações

- **ArtistaComissaoDetalhes**: substitui select de status por botões Aceitar/Recusar quando comissão está PENDING
  - Aceitar -> status IN_PROGRESS, Recusar -> status CANCELLED
  - Após ação, esconde botões e mostra select sem PENDING
  - Altera cor do header conforme status (aceita verde, recusada vermelho)
  - Mensagens contextuais no lugar do select

- **ClienteComissaoDetalhes**: banners contextuais de status (aguardando, recusada, aceita, concluida)

- 184 testes passando (110 frontend + 74 backend)