### PR TITLE
feat: filter artist clients by commissions — GET /users/clients (ID13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 ## Comandos
 - `npm run dev:api` — inicia backend (localhost:3000)
 - `npm run dev:web` — inicia frontend
-- `npm run test -w apps/backend` — 40 testes unitários
+- `npm run test -w apps/backend` — 74 testes unitários
 
 ## Documentação
 - `docs/prd.md` — Product Requirements Document
@@ -23,3 +23,39 @@
 ## Provedor de Banco
 - Neon (PostgreSQL serverless)
 - DATABASE_URL armazenada em `apps/backend/.env` (não versionado)
+
+---
+## Sessão
+
+**Branch atual:** `feature/accept-refuse-commission`
+**Últimos PRs:** #44, #45 (abertos, aguardando merge) | #40–#43 (merged em `develop`) | #46 (acabado de criar)
+
+### Done — Tudo merged em `develop` (PRs #40–#43):
+- Auth flow (auto-login after register, unwrap interceptor, password toggle) (#40)
+- Landing, NotFound, Unauthorized (#41)
+- Artist Dashboard com summary cards / status update (#42)
+- Phase 1 — client flow, commission detail, artist detail (#43)
+
+### Done — Em PRs abertos (#44, #45):
+- `ArtistaClientes` — listagem de clientes com busca (#44)
+- `ClienteNovaComissao` — formulário de criação (#44)
+- `ArtistaComissaoDetalhes` — formulário de entrega + listagem (#45)
+- `Perfil` — página de perfil do usuário (#45)
+- Header atualizado com link `/perfil` (#45)
+- CI workflow (lint + test) (#45)
+
+### Done — Neste PR (#46):
+- Accept/refuse buttons no lugar do select de status (PENDING)
+- Contextual status banners no cliente
+- 110 frontend + 74 backend = 184 testes verdes
+
+### Próximos (ID17):
+- Deploy: Render (backend) + Vercel (frontend)
+- Banco já em Neon nuvem
+
+### Decisões
+- **Commission flow:** Client cria → Artist aceita/recusa explicitamente (botões) → IN_PROGRESS / CANCELLED
+- **PENDING:** artista vê botões, não select. Após ação, select sem PENDING
+- **Pagamento:** fora da plataforma (nenhuma integração)
+- **Trocar senha:** ghost button no Perfil (placeholder)
+- **Deploy:** Render API + Vercel UI

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -12,6 +12,7 @@ describe('UsersController', () => {
   const mockService = {
     findAll: jest.fn(),
     findOne: jest.fn(),
+    findArtistClients: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
   };
@@ -45,6 +46,20 @@ describe('UsersController', () => {
       mockService.findAll.mockResolvedValue(expected);
 
       const result = await controller.findAll();
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('findClients', () => {
+    it('should call service.findArtistClients with the authenticated user id', async () => {
+      const user = { id: 'artist-uuid', role: 'ARTIST' };
+      const req = { user };
+      const expected = [{ id: 'client-1', name: 'Maria' }];
+      mockService.findArtistClients.mockResolvedValue(expected);
+
+      const result = await controller.findClients(req as unknown as Request);
+
+      expect(mockService.findArtistClients).toHaveBeenCalledWith('artist-uuid');
       expect(result).toEqual(expected);
     });
   });

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -36,6 +36,14 @@ export class UsersController {
     return this.usersService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ARTIST)
+  @Get('clients')
+  findClients(@Req() req: Request) {
+    const user = req.user as { id: string };
+    return this.usersService.findArtistClients(user.id);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get(':id')
   findOne(@Req() req: Request, @Param('id') id: string) {

--- a/apps/backend/src/users/users.service.spec.ts
+++ b/apps/backend/src/users/users.service.spec.ts
@@ -94,6 +94,36 @@ describe('UsersService', () => {
     });
   });
 
+  describe('findArtistClients', () => {
+    it('should return only CLIENT users with commissions for the artist', async () => {
+      const artistId = 'artist-uuid';
+      const expected = [
+        { id: 'client-1', name: 'Maria', role: 'CLIENT' },
+        { id: 'client-2', name: 'João', role: 'CLIENT' },
+      ];
+      mockPrisma.user.findMany.mockResolvedValue(expected);
+
+      const result = await service.findArtistClients(artistId);
+
+      expect(mockPrisma.user.findMany).toHaveBeenCalledWith({
+        where: {
+          role: 'CLIENT',
+          commissionsAsClient: { some: { artistId } },
+        },
+        omit: { password: true },
+      });
+      expect(result).toEqual(expected);
+    });
+
+    it('should return empty array when no clients have commissions', async () => {
+      mockPrisma.user.findMany.mockResolvedValue([]);
+
+      const result = await service.findArtistClients('artist-uuid');
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('findOne', () => {
     it('should return a user by id without password', async () => {
       const expected = { id: 'uuid-1', name: 'John' };

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -31,6 +31,16 @@ export class UsersService {
     return this.prisma.user.findMany({ omit: { password: true } });
   }
 
+  async findArtistClients(artistId: string) {
+    return this.prisma.user.findMany({
+      where: {
+        role: 'CLIENT',
+        commissionsAsClient: { some: { artistId } },
+      },
+      omit: { password: true },
+    });
+  }
+
   async findByEmail(email: string) {
     return this.prisma.user.findUnique({ where: { email } });
   }

--- a/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.test.tsx
+++ b/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.test.tsx
@@ -22,13 +22,6 @@ const users: User[] = [
     role: 'CLIENT',
     createdAt: '2024-03-20',
   },
-  {
-    id: '3',
-    name: 'Carlos Artista',
-    email: 'carlos@test.com',
-    role: 'ARTIST',
-    createdAt: '2024-02-10',
-  },
 ]
 
 let mock: MockAdapter
@@ -48,15 +41,15 @@ function renderPage() {
 describe('ArtistaClientes', () => {
   it('shows loading state initially', () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(() => new Promise(() => {}))
+    mock.onGet('/users/clients').reply(() => new Promise(() => {}))
 
     renderPage()
     expect(screen.getByText(/carregando/i)).toBeInTheDocument()
   })
 
-  it('renders list of users', async () => {
+  it('renders list of clients', async () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(200, users)
+    mock.onGet('/users/clients').reply(200, users)
 
     renderPage()
 
@@ -64,15 +57,13 @@ describe('ArtistaClientes', () => {
       expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
     })
     expect(screen.getByText('João Cliente')).toBeInTheDocument()
-    expect(screen.getByText('Carlos Artista')).toBeInTheDocument()
     expect(screen.getByText('maria@test.com')).toBeInTheDocument()
-    expect(screen.getAllByText('CLIENT').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('ARTIST')).toBeInTheDocument()
+    expect(screen.getAllByText('CLIENT')).toHaveLength(2)
   })
 
-  it('filters users by search term', async () => {
+  it('filters clients by search term', async () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(200, users)
+    mock.onGet('/users/clients').reply(200, users)
 
     renderPage()
 
@@ -85,23 +76,22 @@ describe('ArtistaClientes', () => {
 
     expect(screen.getByText('Maria Cliente')).toBeInTheDocument()
     expect(screen.queryByText('João Cliente')).not.toBeInTheDocument()
-    expect(screen.queryByText('Carlos Artista')).not.toBeInTheDocument()
   })
 
-  it('shows empty state when no users', async () => {
+  it('shows empty state when no clients', async () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(200, [])
+    mock.onGet('/users/clients').reply(200, [])
 
     renderPage()
 
     await waitFor(() => {
-      expect(screen.getByText(/nenhum usuário/i)).toBeInTheDocument()
+      expect(screen.getByText(/nenhum cliente/i)).toBeInTheDocument()
     })
   })
 
   it('shows error message on API failure', async () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(500)
+    mock.onGet('/users/clients').reply(500)
 
     renderPage()
 
@@ -112,7 +102,7 @@ describe('ArtistaClientes', () => {
 
   it('deletes a user with confirmation', async () => {
     mock = new MockAdapter(api)
-    mock.onGet('/users').reply(200, users)
+    mock.onGet('/users/clients').reply(200, users)
     mock.onDelete('/users/1').reply(200)
 
     const confirmSpy = vi.spyOn(window, 'confirm')

--- a/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
+++ b/apps/frontend/src/pages/ArtistaClientes/ArtistaClientes.tsx
@@ -9,18 +9,18 @@ export function ArtistaClientes() {
   const [search, setSearch] = useState('')
 
   useEffect(() => {
-    api.get<User[]>('/users')
+    api.get<User[]>('/users/clients')
       .then(({ data }) => setUsers(data))
-      .catch(() => setApiError('Erro ao carregar usuários. Tente novamente.'))
+      .catch(() => setApiError('Erro ao carregar clientes. Tente novamente.'))
       .finally(() => setIsLoading(false))
   }, [])
 
   function handleRetry() {
     setIsLoading(true)
     setApiError('')
-    api.get<User[]>('/users')
+    api.get<User[]>('/users/clients')
       .then(({ data }) => setUsers(data))
-      .catch(() => setApiError('Erro ao carregar usuários. Tente novamente.'))
+      .catch(() => setApiError('Erro ao carregar clientes. Tente novamente.'))
       .finally(() => setIsLoading(false))
   }
 
@@ -87,7 +87,7 @@ export function ArtistaClientes() {
       {filtered.length === 0 ? (
         <div className="rounded-sm border border-[#e5e4e7] bg-surface p-12 text-center">
           <p className="text-tertiary">
-            {search ? 'Nenhum usuário encontrado para esta busca.' : 'Nenhum usuário cadastrado.'}
+            {search ? 'Nenhum cliente encontrado para esta busca.' : 'Nenhum cliente encontrado.'}
           </p>
         </div>
       ) : (

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -321,6 +321,32 @@ Response:
 
 ---
 
+## GET /users/clients
+
+Retorna apenas os clientes (`CLIENT`) que já criaram ao menos uma comissão com o artista autenticado. Exclui artistas e clientes que nunca comissionaram este artista.
+
+Permissão:
+
+```
+ARTIST
+```
+
+Response:
+
+```json
+[
+  {
+    "id": "uuid",
+    "name": "string",
+    "email": "string",
+    "role": "CLIENT",
+    "createdAt": "datetime"
+  }
+]
+```
+
+---
+
 ## GET /users/:id
 
 Retorna os detalhes de um usuário específico.


### PR DESCRIPTION
## Problema

A listagem de clientes (rota /artista/clientes) chamava GET /users que retornava todos os usuarios cadastrados — incluindo artistas e clientes sem comissoes com o artista.

## Solucao

### Backend — novo endpoint GET /users/clients

- UsersService.findArtistClients(artistId): query Prisma que retorna apenas usuarios com role CLIENT que tenham ao menos uma commission com o artista autenticado
- UsersController.findClients: endpoint protegido com Roles(ARTIST), extrai ID do JWT e chama o service
- 3 novos testes (service + controller)

### Frontend — ArtistaClientes

- Chamada alterada de /users para /users/clients
- Mensagem de empty state atualizada
- Testes atualizados (mock endpoint, removido artista dos fixtures)

### Docs

- docs/sdd.md: documentado GET /users/clients

## Testes

- 77 backend + 110 frontend = 187 testes verdes
- ESLint limpo em ambos workspaces