### PR TITLE
chore: pre-deploy setup — fix tsconfig build + create vercel.json (ID17)

### DIFF
--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -21,5 +21,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "rootDirectory": "apps/frontend",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://commission-track-api.onrender.com/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Mudancas

### apps/frontend/tsconfig.app.json
- Adicionado exclude para test files (.test.ts, .test.tsx)
- Resolve erro Cannot find name 'afterEach' que impedia o build

### vercel.json (novo)
Configuracoes para deploy no Vercel:
- rootDirectory: apps/frontend
- buildCommand: npm run build
- outputDirectory: dist
- Rewrite de API para o Render (placeholder, atualizar apos deploy)
- Rewrite SPA com fallback para index.html

## Build & Testes
- Build do frontend: OK (tsc -b + vite build)
- 110 frontend + 77 backend = 187 testes verdes
- ESLint limpo em ambos workspaces